### PR TITLE
Updates the release script in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "jest",
     "test:watch": "jest --watchAll",
     "lint": "tslint --project tsconfig.json --config tslint.json && tsc --noEmit --project tsconfig.json",
-    "release": "np --no-yarn && git push https://github.com/geostyler/geostyler-openlayers-parser.git master --tags"
+    "release": "np --no-yarn && git push https://github.com/geostyler/geostyler-openlayers-parser.git master"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",


### PR DESCRIPTION
As the tags are already pushed by np the git push fails which results in not having the package.json pushed.