### PR TITLE
Parse lineDash null as undefined

### DIFF
--- a/data/styles/multi_simplefillSimpleline.ts
+++ b/data/styles/multi_simplefillSimpleline.ts
@@ -14,7 +14,7 @@ const multiSimplefillSimpleline: Style = {
         kind: 'Line',
         color: '#FF0000',
         width: 5,
-        dasharray: null,
+        dasharray: undefined,
         opacity: undefined
       }]
     }

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -198,6 +198,8 @@ export class OlStyleParser implements StyleParser {
    */
   getLineSymbolizerFromOlStyle(olStyle: any): LineSymbolizer {
     const olStrokeStyle = olStyle.getStroke();
+    // getLineDash returns null not undefined. So we have to double check
+    const dashArray = olStrokeStyle ? olStrokeStyle.getLineDash() : undefined;
 
     return {
       kind: 'Line',
@@ -206,7 +208,7 @@ export class OlStyleParser implements StyleParser {
       width: olStrokeStyle ? olStrokeStyle.getWidth() : undefined,
       cap: olStrokeStyle ? <LineSymbolizer['cap']> olStrokeStyle.getLineCap() : 'butt',
       join: olStrokeStyle ? <LineSymbolizer['join']> olStrokeStyle.getLineJoin() : 'miter',
-      dasharray: olStrokeStyle ? olStrokeStyle.getLineDash() : undefined,
+      dasharray: dashArray ? dashArray : undefined,
       dashOffset: olStrokeStyle ? olStrokeStyle.getLineDashOffset() : undefined
     };
   }


### PR DESCRIPTION
If no lineDash was defined in an openlayers `Stroke` it will be set to `null` by default. This leads to errors in the UI as defaultProps will not be used on `null` values. 

To have a consistent handling ol-parser checks now if lineDash is `null` and sets it to `undefined`.