### PR TITLE
Support font-based mark symbolizers

### DIFF
--- a/data/olStyles/point_fontglyph.ts
+++ b/data/olStyles/point_fontglyph.ts
@@ -1,0 +1,19 @@
+import OlStyle from 'ol/style/Style';
+import OlStyleText from 'ol/style/Text';
+import OlStyleFill from 'ol/style/Fill';
+import OlStyleStroke from 'ol/style/Stroke';
+
+const olFontGlyph = new OlStyle({
+  text: new OlStyleText({
+    text: '|',
+    font: 'Normal 12px \'My Font Name\', geostyler-mark-symbolizer',
+    fill: new OlStyleFill({
+      color: '#FF0000'
+    }),
+    stroke: new OlStyleStroke({
+      color: '#112233'
+    })
+  })
+});
+
+export default olFontGlyph;

--- a/data/styles/point_fontglyph.ts
+++ b/data/styles/point_fontglyph.ts
@@ -1,0 +1,20 @@
+import { Style } from 'geostyler-style';
+
+const pointFontglyph: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'ttf://My Font Name#0x7c',
+        color: '#FF0000',
+        radius: 12,
+        rotate: 0,
+        strokeColor: '#112233'
+      }]
+    }
+  ]
+};
+
+export default pointFontglyph;

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -34,6 +34,7 @@ import scaleDenomLineCircle from '../data/styles/scaleDenom_line_circle';
 import scaleDenomLineCircleOverlap from '../data/styles/scaleDenom_line_circle_overlap';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
+import point_fontglyph from '../data/styles/point_fontglyph';
 import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
 import ol_point_icon from '../data/olStyles/point_icon';
 import ol_point_simplesquare from '../data/olStyles/point_simplesquare';
@@ -54,6 +55,7 @@ import ol_line_simpleline from '../data/olStyles/line_simpleline';
 import ol_polygon_transparentpolygon from '../data/olStyles/polygon_transparentpolygon';
 import ol_multi_simplefillSimpleline from '../data/olStyles/multi_simplefillSimpleline';
 import ol_point_styledLabel_static from '../data/olStyles/point_styledLabel_static';
+import ol_point_fontglyph from '../data/olStyles/point_fontglyph';
 import {
   LineSymbolizer,
   FillSymbolizer,
@@ -287,6 +289,14 @@ describe('OlStyleParser implements StyleParser', () => {
     //       expect(geoStylerStyle).toEqual(point_simplepoint_filter);
     //     });
     // });
+    it('can read a OpenLayers MarkSymbolizer based on a font glyph (WellKnownName starts with ttf://)', () => {
+      expect.assertions(2);
+      return styleParser.readStyle(ol_point_fontglyph)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_fontglyph);
+        });
+    });
 
     describe('#olStyleToGeoStylerStyle', () => {
       it('is defined', () => {
@@ -758,6 +768,28 @@ describe('OlStyleParser implements StyleParser', () => {
           const olTimesFill: OlStyleFill = olTimes.getFill();
           expect(olTimesFill).toBeDefined();
           expect(olTimesFill.getColor()).toEqual(expecSymb.color);
+        });
+    });
+    it('can write a OpenLayers Style based on a font glyph (WellKnownName starts with ttf://)', () => {
+      expect.assertions(8);
+      return styleParser.writeStyle(point_fontglyph)
+        .then((olStyle: OlStyle) => {
+          expect(olStyle).toBeDefined();
+
+          const expecSymb = point_fontglyph.rules[0].symbolizers[0] as MarkSymbolizer;
+          const olText: OlStyleText = olStyle.getText();
+          expect(olText).toBeDefined();
+
+          expect(olText.getFont()).toBe('Normal 12px \'My Font Name\', geostyler-mark-symbolizer');
+          expect(olText.getText()).toBe('|');
+
+          const olTextFill: OlStyleFill = olText.getFill();
+          expect(olTextFill).toBeDefined();
+          expect(olTextFill.getColor()).toEqual(expecSymb.color);
+
+          const olTextStroke: OlStyleStroke = olText.getStroke();
+          expect(olTextStroke).toBeDefined();
+          expect(olTextStroke.getColor()).toEqual(expecSymb.strokeColor);
         });
     });
     it('can write a OpenLayers LineSymbolizer', () => {

--- a/src/Util/OlStyleUtil.spec.ts
+++ b/src/Util/OlStyleUtil.spec.ts
@@ -1,7 +1,7 @@
-import OlStyleUtil from './OlStyleUtil';
+import OlStyleUtil, { DUMMY_MARK_SYMBOLIZER_FONT } from './OlStyleUtil';
 import OlFeature from 'ol/Feature';
 import OlGeomPoint from 'ol/geom/Point';
-import { TextSymbolizer } from 'geostyler-style';
+import { MarkSymbolizer, TextSymbolizer } from 'geostyler-style';
 
 describe('OlStyleUtil', () => {
 
@@ -81,7 +81,7 @@ describe('OlStyleUtil', () => {
       expect(OlStyleUtil.getTextFont).toBeDefined();
     });
 
-    it('returns correct opacity', () => {
+    it('returns correct font', () => {
       const symb: TextSymbolizer = {
         kind: 'Text',
         color: '#000000',
@@ -92,6 +92,135 @@ describe('OlStyleUtil', () => {
       };
       const opac = OlStyleUtil.getTextFont(symb);
       expect(opac).toEqual('Normal 12px Arial');
+    });
+  });
+
+  describe('#getIsFontGlyphBased', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getIsFontGlyphBased).toBeDefined();
+    });
+
+    it('returns false if wellknownname is not based on a font glyph', () => {
+      const symb: MarkSymbolizer = {
+        kind: 'Mark',
+        color: '#000000',
+        wellKnownName: 'shape://backslash'
+      };
+      const isGlyph = OlStyleUtil.getIsFontGlyphBased(symb);
+      expect(isGlyph).toEqual(false);
+    });
+
+    it('returns true if wellknownname is based on a font glyph', () => {
+      const symb: MarkSymbolizer = {
+        kind: 'Mark',
+        color: '#000000',
+        wellKnownName: 'ttf://Webdings#0x0064'
+      };
+      const isGlyph = OlStyleUtil.getIsFontGlyphBased(symb);
+      expect(isGlyph).toEqual(true);
+    });
+  });
+
+  describe('#getIsMarkSymbolizerFont', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getIsMarkSymbolizerFont).toBeDefined();
+    });
+
+    it('returns false if the font was not intended for a mark symbolizer', () => {
+      const font = '12px \'Arial Black\'';
+      const isMark = OlStyleUtil.getIsMarkSymbolizerFont(font);
+      expect(isMark).toEqual(false);
+    });
+
+    it('returns true if the font was intended for a mark symbolizer', () => {
+      const font = `Normal 12px 'Arial Black', ${DUMMY_MARK_SYMBOLIZER_FONT}`;
+      const isMark = OlStyleUtil.getIsMarkSymbolizerFont(font);
+      expect(isMark).toEqual(true);
+    });
+  });
+
+  describe('#getTextFontForMarkSymbolizer', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getTextFontForMarkSymbolizer).toBeDefined();
+    });
+
+    it('returns correct font', () => {
+      const symb: MarkSymbolizer = {
+        kind: 'Mark',
+        color: '#000000',
+        radius: 10,
+        wellKnownName: 'ttf://Arial Black#0x0064'
+      };
+      const font = OlStyleUtil.getTextFontForMarkSymbolizer(symb);
+      expect(font).toEqual(`Normal 10px 'Arial Black', ${DUMMY_MARK_SYMBOLIZER_FONT}`);
+    });
+
+    it('returns correct font (with default size)', () => {
+      const symb: MarkSymbolizer = {
+        kind: 'Mark',
+        color: '#000000',
+        wellKnownName: 'ttf://Arial Black#0x0064'
+      };
+      const font = OlStyleUtil.getTextFontForMarkSymbolizer(symb);
+      expect(font).toEqual(`Normal 5px 'Arial Black', ${DUMMY_MARK_SYMBOLIZER_FONT}`);
+    });
+  });
+
+  describe('#getCharacterForMarkSymbolizer', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getCharacterForMarkSymbolizer).toBeDefined();
+    });
+
+    it('returns correct character', () => {
+      const symb: MarkSymbolizer = {
+        kind: 'Mark',
+        color: '#000000',
+        wellKnownName: 'ttf://Arial Black#0x0064'
+      };
+      const char = OlStyleUtil.getCharacterForMarkSymbolizer(symb);
+      expect(char).toEqual('d');
+    });
+  });
+
+  describe('#getFontNameFromOlFont', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getFontNameFromOlFont).toBeDefined();
+    });
+
+    it('returns correct font name (1)', () => {
+      const name = OlStyleUtil.getFontNameFromOlFont(`Normal 13px 'Arial Sans', sans-serif`);
+      expect(name).toEqual('Arial Sans');
+    });
+
+    it('returns correct font name (2)', () => {
+      const name = OlStyleUtil.getFontNameFromOlFont(`10px Arial`);
+      expect(name).toEqual('Arial');
+    });
+
+    it('returns correct font name (3)', () => {
+      const name = OlStyleUtil.getFontNameFromOlFont(`italic 1.2em "Fira Sans", serif`);
+      expect(name).toEqual('Fira Sans');
+    });
+  });
+
+  describe('#getSizeFromOlFont', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getSizeFromOlFont).toBeDefined();
+    });
+
+    it('returns correct size in pixels (1)', () => {
+      const size = OlStyleUtil.getSizeFromOlFont(`Normal 13px 'Arial Sans', sans-serif`);
+      expect(size).toEqual(13);
+    });
+
+    it('returns correct size in pixels (2)', () => {
+      const size = OlStyleUtil.getSizeFromOlFont(`10px Arial`);
+      expect(size).toEqual(10);
+    });
+
+    it('returns 0 if no available size in pixels', () => {
+      const size = OlStyleUtil.getSizeFromOlFont(`italic 1.2em "Fira Sans", serif`);
+      expect(size).toEqual(0);
     });
   });
 


### PR DESCRIPTION
This PR extends the parser logic to allow rendering mark symbolizers using font glyphs instead of built-in shapes (`Circle`, `Square`, `shape://...` etc.). This is done by specifying a WellKnownName property with the following syntax: `ttf://<font name>#<char hex code>`.

The change works both ways (Geostyler > OL and OL > Geostyler), the caveat being that if an OL style was created *without* using the parser and that it contains a text style meant for symbols, the parser will have no way of knowing that it is supposed to be a `MarkSymbolizer` and not a `TextSymbolizer`.

This is because when generating an OL style containing a font-based mark, the resulting text style will contain a dummy `geostyler-mark-symbolizer` font which does not impact rendering but lets the parser know that it is meant to be a mark symbolizer.

I haven't found a cleaner way of handling both transformations in a reversible way, but I'm open to suggestion!

Fixes https://github.com/geostyler/geostyler-openlayers-parser/issues/230