### PR TITLE
Add support for outlineOpacity and outlineDasharray in fill symbolizer

### DIFF
--- a/data/olStyles/polygon_transparentpolygon.ts
+++ b/data/olStyles/polygon_transparentpolygon.ts
@@ -4,7 +4,9 @@ import OlStyleFill from 'ol/style/Fill';
 
 const olPolygonTransparentPolygon = new OlStyle({
   stroke: new OlStyleStroke({
-    color: '#FFFFFF'
+    color: 'rgba(255,255,255,0.7)',
+    lineDash: [10, 15],
+    width: 2
   }),
   fill: new OlStyleFill({
     color: 'rgba(0,0,128,0.5)'

--- a/data/styles/polygon_transparentpolygon.ts
+++ b/data/styles/polygon_transparentpolygon.ts
@@ -9,7 +9,10 @@ const polygonTransparentPolygon: Style = {
         kind: 'Fill',
         color: '#000080',
         opacity: 0.5,
-        outlineColor: '#FFFFFF'
+        outlineColor: '#ffffff',
+        outlineDasharray: [10, 15],
+        outlineOpacity: 0.7,
+        outlineWidth: 2
       }]
     }
   ]

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -808,22 +808,27 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers PolygonSymbolizer', () => {
-      expect.assertions(5);
+      expect.assertions(6);
       return styleParser.writeStyle(polygon_transparentpolygon)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
 
           const expecSymb = polygon_transparentpolygon.rules[0].symbolizers[0] as FillSymbolizer;
           const olStroke = olStyle.getStroke();
-
           expect(olStroke).toBeDefined();
-          expect(olStroke.getColor()).toEqual(expecSymb.outlineColor);
+
+          const expecSymbOutlCol: string = expecSymb.outlineColor as string;
+          const expecSymbOutlOpac: number = expecSymb.outlineOpacity as number;
+          expect(olStroke.getColor()).toEqual(OlStyleUtil.getRgbaColor(expecSymbOutlCol, expecSymbOutlOpac));
 
           const olFill = olStyle.getFill();
           expect(olFill).toBeDefined();
-          const expecSymbCol: string = expecSymb.color as string;
-          const expecSymbOpac: number = expecSymb.opacity as number;
-          expect(olFill.getColor()).toEqual(OlStyleUtil.getRgbaColor(expecSymbCol, expecSymbOpac));
+
+          const expecSymbFillCol: string = expecSymb.color as string;
+          const expecSymbFillOpac: number = expecSymb.opacity as number;
+          expect(olFill.getColor()).toEqual(OlStyleUtil.getRgbaColor(expecSymbFillCol, expecSymbFillOpac));
+
+          expect(olStroke.getLineDash()).toEqual(expecSymb.outlineDasharray);
         });
     });
     it('can write a OpenLayers TextSymbolizer', () => {

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -949,14 +949,18 @@ export class OlStyleParser implements StyleParser {
    */
   getOlPolygonSymbolizerFromFillSymbolizer(symbolizer: FillSymbolizer) {
     const fill = symbolizer.color ? new this.OlStyleFillConstructor({
-      color: (symbolizer.color && symbolizer.opacity !== null && symbolizer.opacity !== undefined) ?
+      color: (symbolizer.opacity !== null && symbolizer.opacity !== undefined) ?
         OlStyleUtil.getRgbaColor(symbolizer.color, symbolizer.opacity) : symbolizer.color
     }) : null;
+
+    const stroke = symbolizer.outlineColor ? new this.OlStyleStrokeConstructor({
+      color: (symbolizer.outlineOpacity !== null && symbolizer.outlineOpacity !== undefined) ?
+        OlStyleUtil.getRgbaColor(symbolizer.outlineColor, symbolizer.outlineOpacity) : symbolizer.outlineColor,
+      width: symbolizer.outlineWidth
+    }) : null;
+
     return new this.OlStyleConstructor({
-      stroke: new this.OlStyleStrokeConstructor({
-        color: symbolizer.outlineColor,
-        width: symbolizer.outlineWidth
-      }),
+      stroke: stroke,
       fill: fill
     });
   }

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -246,12 +246,16 @@ export class OlStyleParser implements StyleParser {
   getFillSymbolizerFromOlStyle(olStyle: any): FillSymbolizer {
     const olFillStyle = olStyle.getFill();
     const olStrokeStyle = olStyle.getStroke();
+    // getLineDash returns null not undefined. So we have to double check
+    const outlineDashArray = olStrokeStyle ? olStrokeStyle.getLineDash() : undefined;
 
     return {
       kind: 'Fill',
       color: olFillStyle ? OlStyleUtil.getHexColor(olFillStyle.getColor() as string) : undefined,
       opacity: olFillStyle ? OlStyleUtil.getOpacity(olFillStyle.getColor() as string) : undefined,
-      outlineColor: olStrokeStyle ? olStrokeStyle.getColor() as string : undefined,
+      outlineColor: olStrokeStyle ? OlStyleUtil.getHexColor(olStrokeStyle.getColor() as string) : undefined,
+      outlineDasharray: outlineDashArray ? outlineDashArray : undefined,
+      outlineOpacity: olStrokeStyle ? OlStyleUtil.getOpacity(olStrokeStyle.getColor() as string) : undefined,
       outlineWidth: olStrokeStyle ? olStrokeStyle.getWidth() as number : undefined
     };
   }
@@ -956,7 +960,8 @@ export class OlStyleParser implements StyleParser {
     const stroke = symbolizer.outlineColor ? new this.OlStyleStrokeConstructor({
       color: (symbolizer.outlineOpacity !== null && symbolizer.outlineOpacity !== undefined) ?
         OlStyleUtil.getRgbaColor(symbolizer.outlineColor, symbolizer.outlineOpacity) : symbolizer.outlineColor,
-      width: symbolizer.outlineWidth
+      width: symbolizer.outlineWidth,
+      lineDash: symbolizer.outlineDasharray,
     }) : null;
 
     return new this.OlStyleConstructor({


### PR DESCRIPTION
## Description

Currently the OL parser isn't (fully) supporting outlineOpacity and outlineDasharray in the Fill symbolizer. This PR aims to add support for this. It also likely fixes #229 and geostyler/geostyler#1222.

~Please let me know if this feature is of interest and if I'm on the right path with the implementation. I'll then add relevant tests. :-)~ 
Tests have now been added, thanks for the encouragement, @jansule!

## Pull request type

Please check the type of change your PR introduces:

* [ ]  Bugfix
* [x]  Feature
* [ ]  Dependency updates
* [ ]  Code style update (formatting, renaming)
* [ ]  Refactoring (no functional changes, no api changes)
* [ ]  Build related changes
* [ ]  Documentation content changes
* [ ]  Other (please describe)
* [ ]  I am unsure (we'll look into it together)

## Do you introduce a breaking change?

* [ ]  Yes
* [x]  No
* [ ]  I am unsure (no worries, we'll find out)

## Checklist

* [x]  I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
* [x]  I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
* [x]  The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
* [x]  I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
* [ ]  I'm lost; why do I have to check so many boxes? Please help!

Please note, I copy/pasted the template from the geostyler/geostyler repo. Maybe it would be good to have a template for this repo available too?

