### PR TITLE
Add graphicFill read support for polygon symbolizer (WIP)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,10 @@
 declare module '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 declare module 'ol/Feature';
+declare module 'ol/has';
 declare module 'ol/geom/Point';
+declare module 'ol/ImageState';
+declare module 'ol/render';
 declare module 'ol/style/Circle';
 declare module 'ol/style/Fill';
 declare module 'ol/style/Icon';


### PR DESCRIPTION
## Description

The PR adds support for creating OL graphic fill styles from polygon symbolizer. Only types of `Icon` and `Mark` are supported.

It uses the newish renderer function for OL styles, which has one unfortunate drawback: it breaks the `zIndex` ordering and always draws the symbolizer on top of other ones.

![geostyler-polygon-graphic-fill-example](https://user-images.githubusercontent.com/219691/109101712-5d019680-777b-11eb-8b0e-ad2ed7881686.png)

## Related issues or pull requests

This could solve #240

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [X] Feature
- [ ] Dependency updates
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [X] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [X] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [X] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [X] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
