### PR TITLE
Support dynamic attribute based point icons

### DIFF
--- a/data/styles/point_dynamic_icon.ts
+++ b/data/styles/point_dynamic_icon.ts
@@ -1,0 +1,16 @@
+import { Style } from 'geostyler-style';
+
+const pointDynamicIconPoint: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Icon',
+        image: '{{path}}',
+      }]
+    }
+  ]
+};
+
+export default pointDynamicIconPoint;

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -8,6 +8,7 @@ import OlStyleParser, { OlParserStyleFct } from './OlStyleParser';
 
 import point_simplepoint from '../data/styles/point_simplepoint';
 import point_icon from '../data/styles/point_icon';
+import point_dynamic_icon from '../data/styles/point_dynamic_icon';
 import point_simplesquare from '../data/styles/point_simplesquare';
 import point_simplestar from '../data/styles/point_simplestar';
 import point_simpletriangle from '../data/styles/point_simpletriangle';
@@ -489,6 +490,24 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olIcon.getOpacity()).toBeCloseTo(expecSymb.opacity);
 
           expect(olIcon).toBeDefined();
+        });
+    });
+    it('can write an OpenLayers IconSymbolizer f-n with with feature attrib based src', () => {
+      expect.assertions(5);
+      return styleParser.writeStyle(point_dynamic_icon)
+        .then((olStyle: OlStyle) => {
+          expect(olStyle).toBeDefined();
+          const dummyFeat = new OlFeature({
+            path: 'image.jpg'
+          });
+
+          const styles = olStyle(dummyFeat, 1);
+          expect(styles).toBeDefined();
+          expect(styles).toHaveLength(1);
+
+          const olIcon: OlStyleIcon = styles[0].getImage() as OlStyleIcon;
+          expect(olIcon).toBeDefined();        
+          expect(olIcon.getSrc()).toEqual(dummyFeat.get('path'));
         });
     });
     it('can write a OpenLayers RegularShape square', () => {

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -492,7 +492,7 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olIcon).toBeDefined();
         });
     });
-    it('can write an OpenLayers IconSymbolizer f-n with with feature attrib based src', () => {
+    it('can write an OpenLayers IconSymbolizer with feature attribute based src', () => {
       expect.assertions(5);
       return styleParser.writeStyle(point_dynamic_icon)
         .then((olStyle: OlStyle) => {

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -921,7 +921,7 @@ export class OlStyleParser implements StyleParser {
       // Rotation in openlayers is radians while we use degree
       rotation: symbolizer.rotate ? symbolizer.rotate * Math.PI / 180 : undefined
     };
-    // check if TextSymbolizer.image contains a placeholder
+    // check if IconSymbolizer.image contains a placeholder
     const prefix = '\\{\\{';
     const suffix = '\\}\\}';
     const regExp = new RegExp(prefix + '.*?' + suffix, 'g');

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -481,7 +481,10 @@ export class OlStyleParser implements StyleParser {
       const hasTextSymbolizer = rules[0].symbolizers.some((symbolizer: Symbolizer) => {
         return symbolizer.kind === 'Text';
       });
-      if (!hasFilter && !hasScaleDenominator && !hasTextSymbolizer) {
+      const hasDynamicIconSymbolizer = rules[0].symbolizers.some((symbolizer: Symbolizer) => {
+        return symbolizer.kind === 'Icon' && symbolizer.image?.includes('{{');
+      });
+      if (!hasFilter && !hasScaleDenominator && !hasTextSymbolizer && !hasDynamicIconSymbolizer) {
         if (nrSymbolizers === 1) {
           return this.geoStylerStyleToOlStyle(geoStylerStyle);
         } else {
@@ -910,16 +913,44 @@ export class OlStyleParser implements StyleParser {
    * @return {object} The OL Style object
    */
   getOlIconSymbolizerFromIconSymbolizer(symbolizer: IconSymbolizer): any {
-    return new this.OlStyleConstructor({
-      image: new this.OlStyleIconConstructor({
-        src: symbolizer.image,
-        crossOrigin: 'anonymous',
-        opacity: symbolizer.opacity,
-        scale: symbolizer.size || 1,
-        // Rotation in openlayers is radians while we use degree
-        rotation: symbolizer.rotate ? symbolizer.rotate * Math.PI / 180 : undefined
-      })
-    });
+    const baseProps = {
+      src: symbolizer.image,
+      crossOrigin: 'anonymous',
+      opacity: symbolizer.opacity,
+      scale: symbolizer.size || 1,
+      // Rotation in openlayers is radians while we use degree
+      rotation: symbolizer.rotate ? symbolizer.rotate * Math.PI / 180 : undefined
+    };
+    // check if TextSymbolizer.image contains a placeholder
+    const prefix = '\\{\\{';
+    const suffix = '\\}\\}';
+    const regExp = new RegExp(prefix + '.*?' + suffix, 'g');
+    const regExpRes = symbolizer.image ? symbolizer.image.match(regExp) : null;
+    if (regExpRes) {
+      // if it contains a placeholder
+      // return olStyleFunction
+      const olPointStyledIconFn = (feature: any) => {
+        let src: string | undefined = OlStyleUtil.resolveAttributeTemplate(feature, symbolizer.image as string, '');
+        // src can't be blank, would trigger ol errors
+        if(!src) {
+          src = symbolizer.image;
+        }
+        const image = new this.OlStyleIconConstructor({
+          ...baseProps,
+          src // order is important
+        });
+        return new this.OlStyleConstructor({
+          image
+        });
+      };
+      return olPointStyledIconFn;
+    } else {
+      return new this.OlStyleConstructor({
+        image: new this.OlStyleIconConstructor({
+          ...baseProps
+        })
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

This PR allows deciding IconSymboilizers URL based on features attribute by supporting template literals. We can write `{{path}}` in symbolizer definition
```
 symbolizers: [{
        kind: 'Icon',
        image: '{{path}}',
      }]
``` 
and it would then take the attribute `path` from each feature and generate the URL to load the icon from.

## Related issues or pull requests

https://github.com/geostyler/geostyler-openlayers-parser/issues/363

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
