### PR TITLE
Cache dynamic icon styles to fix flickering

### DIFF
--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -936,17 +936,26 @@ export class OlStyleParser implements StyleParser {
         if(!src) {
           src = symbolizer.image + '';
         }
+        let image;
         if(this.olIconStyleCache[src]) {
-          return this.olIconStyleCache[src];
+          image = this.olIconStyleCache[src];
+          image.setScale(baseProps.scale);
+          if(baseProps.rotation !== undefined) {
+            image.setRotation(baseProps.rotation);
+          }
+          if(baseProps.opacity !== undefined) {
+            image.setOpacity(baseProps.opacity);
+          }
+        } else {
+          image = new this.OlStyleIconConstructor({
+            ...baseProps,
+            src // order is important
+          });
+          this.olIconStyleCache[src] = image;
         }
-        const image = new this.OlStyleIconConstructor({
-          ...baseProps,
-          src // order is important
-        });
         const style = new this.OlStyleConstructor({
           image
         });
-        this.olIconStyleCache[src] = style;
         return style;
       };
       return olPointStyledIconFn;

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -47,6 +47,7 @@ export class OlStyleParser implements StyleParser {
   public static title = 'OpenLayers Style Parser';
 
   title = 'OpenLayers Style Parser';
+  olIconStyleCache: any = {};
 
   OlStyleConstructor: any = OlStyle;
   OlStyleImageConstructor: any = OlStyleImage;
@@ -930,18 +931,23 @@ export class OlStyleParser implements StyleParser {
       // if it contains a placeholder
       // return olStyleFunction
       const olPointStyledIconFn = (feature: any) => {
-        let src: string | undefined = OlStyleUtil.resolveAttributeTemplate(feature, symbolizer.image as string, '');
+        let src: string = OlStyleUtil.resolveAttributeTemplate(feature, symbolizer.image as string, '');
         // src can't be blank, would trigger ol errors
         if(!src) {
-          src = symbolizer.image;
+          src = symbolizer.image + '';
+        }
+        if(this.olIconStyleCache[src]) {
+          return this.olIconStyleCache[src];
         }
         const image = new this.OlStyleIconConstructor({
           ...baseProps,
           src // order is important
         });
-        return new this.OlStyleConstructor({
+        const style = new this.OlStyleConstructor({
           image
         });
+        this.olIconStyleCache[src] = style;
+        return style;
       };
       return olPointStyledIconFn;
     } else {


### PR DESCRIPTION
## Description

The features start to flicker due to a longstanding bug (https://github.com/openlayers/openlayers/issues/3137) in OpenLayers when using style function to set icon image and having more than 33 features. This PR fixes that problem by caching the styles using src URL as dictionary key.

## Related issues or pull requests

This is a followup of https://github.com/geostyler/geostyler-openlayers-parser/pull/364 for issue https://github.com/geostyler/geostyler-openlayers-parser/issues/363

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
