### PR TITLE
geostyler-style v 5

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,10 +1,10 @@
 module.exports = {
-  "presets": [
-    "@babel/env",
-    "@babel/preset-typescript"
+  'presets': [
+    '@babel/env',
+    '@babel/preset-typescript'
   ],
-  "plugins": [
-    "@babel/proposal-class-properties",
-    "@babel/proposal-object-rest-spread"
+  'plugins': [
+    '@babel/proposal-class-properties',
+    '@babel/proposal-object-rest-spread'
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7958,9 +7958,9 @@
       }
     },
     "geostyler-style": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
-      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.0.0.tgz",
+      "integrity": "sha512-Rsrfat5rZOY3D2vdxB2kkG9xQxztovUnZAKjTVC4TgLdzIEM1lZ73XchfQTqURmhe+m7NpUAALjWAXFwZRCv9w==",
       "requires": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13856,9 +13856,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
       "dev": true
     },
     "regenerator-transform": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "jest-canvas-mock": "^2.3.1",
     "np": "^7.5.0",
     "ol": "^6.7.0",
+    "regenerator-runtime": "^0.13.9",
     "terser-webpack-plugin": "^5.2.4",
     "typescript": "^4.4.3",
     "webpack": "^5.52.1",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,6 @@
     "url": "https://github.com/geostyler/geostyler-openlayers-parser/issues"
   },
   "homepage": "https://github.com/geostyler/geostyler-openlayers-parser#readme",
-  "dependencies": {
-    "@terrestris/ol-util": "^4.0.1",
-    "geostyler-style": "^4.0.0",
-    "lodash": "^4.17.15"
-  },
-  "peerDependencies": {
-    "ol": "^6.0.0"
-  },
   "scripts": {
     "build:browser": "webpack --config browser-build.config.js",
     "build": "tsc -p tsconfig.json && npm run build:browser",
@@ -44,6 +36,14 @@
     "test": "jest --coverage",
     "lint:test": "npm run lint && npm run test",
     "lint:typecheck:test": "npm run lint && npm run typecheck && npm run test"
+  },
+  "dependencies": {
+    "@terrestris/ol-util": "^4.0.1",
+    "geostyler-style": "^5.0.0",
+    "lodash": "^4.17.15"
+  },
+  "peerDependencies": {
+    "ol": "^6.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -1,4 +1,8 @@
-import OlStyle, { Options as StyleOptions, StyleFunction } from 'ol/style/Style';
+import 'regenerator-runtime/runtime';
+
+import OlStyle, {
+  Options as StyleOptions
+} from 'ol/style/Style';
 import OlStyleCircle from 'ol/style/Circle';
 import OlStyleRegularshape from 'ol/style/RegularShape';
 import OlStyleStroke from 'ol/style/Stroke';
@@ -65,7 +69,6 @@ import {
   LineSymbolizer,
   FillSymbolizer,
   TextSymbolizer,
-  Style,
   IconSymbolizer,
   MarkSymbolizer
 } from 'geostyler-style';
@@ -88,219 +91,147 @@ describe('OlStyleParser implements StyleParser', () => {
     it('is defined', () => {
       expect(styleParser.readStyle).toBeDefined();
     });
-    it('can read an OpenLayers Style', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplepoint)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplepoint);
-        });
+    it('can read an OpenLayers Style', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplepoint);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplepoint);
     });
-    it('can read an OpenLayers Style Array', () => {
-      expect.assertions(2);
-      return styleParser.readStyle([ol_point_simplepoint])
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplepoint);
-        });
+    it('can read an OpenLayers Style Array', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle([ol_point_simplepoint]);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplepoint);
     });
-    it('can read an OpenLayers Style Function', () => {
-      expect.assertions(2);
+    it('can read an OpenLayers Style Function', async () => {
       const styleFct: OlParserStyleFct = (feature, resolution) => {
         return ol_point_simplepoint;
       };
       styleFct.__geoStylerStyle = point_simplepoint;
 
-      return styleParser.readStyle(ol_point_simplepoint)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplepoint);
-        });
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplepoint);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplepoint);
     });
-    it('can read a OpenLayers PointSymbolizer', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplepoint)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplepoint);
-        });
+    it('can read a OpenLayers PointSymbolizer', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplepoint);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplepoint);
     });
-    it('can read a OpenLayers IconSymbolizer', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_icon)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_icon);
-        });
+    it('can read a OpenLayers IconSymbolizer', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_icon);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_icon);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName Square', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplesquare)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplesquare);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName Square', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplesquare);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplesquare);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName Star', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplestar)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplestar);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName Star', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplestar);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplestar);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName Triangle', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simpletriangle)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simpletriangle);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName Triangle', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpletriangle);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simpletriangle);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName Cross', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplecross)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplecross);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName Cross', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplecross);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplecross);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName X', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplex)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplex);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName X', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplex);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplex);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://slash', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simpleslash)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simpleslash);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://slash', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpleslash);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simpleslash);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://backslash', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplebackslash)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplebackslash);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://backslash', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplebackslash);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplebackslash);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://vertline', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplevertline)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplevertline);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://vertline', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplevertline);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplevertline);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://horline', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplehorline)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplehorline);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://horline', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplehorline);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplehorline);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://carrow', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplecarrow)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_simplecarrow);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://carrow', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplecarrow);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simplecarrow);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://oarrow', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simpleoarrow)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          // using point_simplecarrow here since reading OlStyle cannot distinguish
-          // between carrow and oarrow
-          expect(geoStylerStyle).toEqual(point_simplecarrow);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://oarrow', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpleoarrow);
+      expect(geoStylerStyle).toBeDefined();
+      // using point_simplecarrow here since reading OlStyle cannot distinguish
+      // between carrow and oarrow
+      expect(geoStylerStyle).toEqual(point_simplecarrow);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://dot', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simpledot)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          // using point_simplepoint here since reading OlStyle cannot distinguish
-          // between circle and dot
-          expect(geoStylerStyle).toEqual(point_simplepoint);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://dot', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpledot);
+      expect(geoStylerStyle).toBeDefined();
+      // using point_simplepoint here since reading OlStyle cannot distinguish
+      // between circle and dot
+      expect(geoStylerStyle).toEqual(point_simplepoint);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://plus', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simpleplus)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          // using point_simplecross here since reading OlStyle cannot distinguish
-          // between cross and plus
-          expect(geoStylerStyle).toEqual(point_simplecross);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://plus', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpleplus);
+      expect(geoStylerStyle).toBeDefined();
+      // using point_simplecross here since reading OlStyle cannot distinguish
+      // between cross and plus
+      expect(geoStylerStyle).toEqual(point_simplecross);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://times', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_simpletimes)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          // using point_simplex here since reading OlStyle cannot distinguish
-          // between x and times
-          expect(geoStylerStyle).toEqual(point_simplex);
-        });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://times', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpletimes);
+      expect(geoStylerStyle).toBeDefined();
+      // using point_simplex here since reading OlStyle cannot distinguish
+      // between x and times
+      expect(geoStylerStyle).toEqual(point_simplex);
     });
-    it('can read a OpenLayers LineSymbolizer', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_line_simpleline)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(line_simpleline);
-        });
+    it('can read a OpenLayers LineSymbolizer', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_line_simpleline);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(line_simpleline);
     });
-    it('can read a OpenLayers PolygonSymbolizer', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_polygon_transparentpolygon)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(polygon_transparentpolygon);
-        });
+    it('can read a OpenLayers PolygonSymbolizer', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_polygon_transparentpolygon);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(polygon_transparentpolygon);
     });
-    it('can read two OpenLayers Styles in one Rule', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_multi_simplefillSimpleline)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(multi_simplefillSimpleline);
-        });
+    it('can read two OpenLayers Styles in one Rule', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_multi_simplefillSimpleline);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(multi_simplefillSimpleline);
     });
-    it('can read a OpenLayers TextSymbolizer with static text', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_styledLabel_static)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_styledLabel_static);
-        });
+    it('can read a OpenLayers TextSymbolizer with static text', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_styledLabel_static);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_styledLabel_static);
     });
     // it('can read a OpenLayers style with a filter', () => {
     //   expect.assertions(2);
     //   const sld = fs.readFileSync( './data/slds/point_simplepoint_filter.sld', 'utf8');
-    //   return styleParser.readStyle(sld)
+    //   const { output: geoStylerStyle } = await styleParser.readStyle(sld)
     //     .then((geoStylerStyle: Style) => {
     //       expect(geoStylerStyle).toBeDefined();
     //       expect(geoStylerStyle).toEqual(point_simplepoint_filter);
     //     });
     // });
-    it('can read a OpenLayers MarkSymbolizer based on a font glyph (WellKnownName starts with ttf://)', () => {
-      expect.assertions(2);
-      return styleParser.readStyle(ol_point_fontglyph)
-        .then((geoStylerStyle: Style) => {
-          expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(point_fontglyph);
-        });
+    it('can read a OpenLayers MarkSymbolizer based on a font glyph (WellKnownName starts with ttf://)', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_fontglyph);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_fontglyph);
     });
 
     describe('#olStyleToGeoStylerStyle', () => {
@@ -445,821 +376,749 @@ describe('OlStyleParser implements StyleParser', () => {
     it('is defined', () => {
       expect(styleParser.writeStyle).toBeDefined();
     });
-    it('returns the right output format', () => {
-      expect.assertions(7);
-      return Promise.all([
-        styleParser.writeStyle(point_simplepoint),
-        styleParser.writeStyle(multi_simplefillSimpleline),
-        styleParser.writeStyle(multi_twoRulesSimplepoint)
-      ]).then((res: any[]) => {
-        const olStyle = res[0];
-        const olStyles = res[1];
-        const olStyleFct = res[2];
-        expect(olStyle).toBeDefined();
-        expect(olStyles).toBeDefined();
-        expect(olStyleFct).toBeDefined();
-        expect(olStyle).toHaveProperty('getImage');
-        expect(Array.isArray(olStyles)).toBe(true);
-        expect(olStyles).toHaveLength(2);
-        expect(typeof olStyleFct === 'function').toBe(true);
+    it('returns the right output format', async () => {
+      let { output: olStyle } = await styleParser.writeStyle(point_simplepoint);
+      const { output: olStyles } = await styleParser.writeStyle(multi_simplefillSimpleline);
+      const { output: olStyleFct } = await styleParser.writeStyle(multi_twoRulesSimplepoint);
+      expect(olStyle).toBeDefined();
+      expect(olStyles).toBeDefined();
+      expect(olStyleFct).toBeDefined();
+      expect(olStyle).toHaveProperty('getImage');
+      expect(Array.isArray(olStyles)).toBe(true);
+      expect(olStyles).toHaveLength(2);
+      expect(typeof olStyleFct === 'function').toBe(true);
+    });
+    it('can write a OpenLayers PointSymbolizer', async () => {
+      let { output: olStyle } = await styleParser.writeStyle(point_simplepoint);
+      olStyle = olStyle as OlStyle;
+      expect(olStyle).toBeDefined();
+
+      const expecSymb = point_simplepoint.rules[0].symbolizers[0] as MarkSymbolizer;
+      const olCircle: OlStyleCircle = olStyle.getImage() as OlStyleCircle;
+
+      expect(olCircle).toBeDefined();
+      expect(olCircle.getRadius()).toBeCloseTo(expecSymb.radius);
+      expect(olCircle.getFill().getColor()).toEqual(expecSymb.color);
+    });
+    it('can write a OpenLayers IconSymbolizer', async () => {
+      let { output: olStyle } = await styleParser.writeStyle(point_icon);
+      olStyle = olStyle as OlStyle;
+      expect(olStyle).toBeDefined();
+
+      const expecSymb = point_icon.rules[0].symbolizers[0] as IconSymbolizer;
+      const olIcon: OlStyleIcon = olStyle.getImage() as OlStyleIcon;
+
+      expect(olIcon.getSrc()).toEqual(expecSymb.image);
+      expect(olIcon.getScale()).toBeCloseTo(expecSymb.size);
+      // Rotation in openlayers is radians while we use degree
+      expect(olIcon.getRotation()).toBeCloseTo(expecSymb.rotate! * Math.PI / 180);
+      expect(olIcon.getOpacity()).toBeCloseTo(expecSymb.opacity);
+
+      expect(olIcon).toBeDefined();
+    });
+    it('can write an OpenLayers IconSymbolizer with feature attribute based src', async () => {
+      let { output: olStyle } = await styleParser.writeStyle(point_dynamic_icon);
+      olStyle = olStyle as OlParserStyleFct;
+      expect(olStyle).toBeDefined();
+      const dummyFeat = new OlFeature({
+        path: 'image.jpg'
       });
+
+      const styles = olStyle(dummyFeat, 1);
+      expect(styles).toBeDefined();
+      expect(styles).toHaveLength(1);
+
+      const olIcon: OlStyleIcon = styles[0].getImage() as OlStyleIcon;
+      expect(olIcon).toBeDefined();
+      expect(olIcon.getSrc()).toEqual(dummyFeat.get('path'));
     });
-    it('can write a OpenLayers PointSymbolizer', () => {
-      expect.assertions(4);
-      return styleParser.writeStyle(point_simplepoint)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simplepoint.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olCircle: OlStyleCircle = olStyle.getImage() as OlStyleCircle;
-
-          expect(olCircle).toBeDefined();
-          expect(olCircle.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olCircle.getFill().getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers IconSymbolizer', () => {
-      expect.assertions(6);
-      return styleParser.writeStyle(point_icon)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_icon.rules[0].symbolizers[0] as IconSymbolizer;
-          const olIcon: OlStyleIcon = olStyle.getImage() as OlStyleIcon;
-
-          expect(olIcon.getSrc()).toEqual(expecSymb.image);
-          expect(olIcon.getScale()).toBeCloseTo(expecSymb.size);
-          // Rotation in openlayers is radians while we use degree
-          expect(olIcon.getRotation()).toBeCloseTo(expecSymb.rotate! * Math.PI / 180);
-          expect(olIcon.getOpacity()).toBeCloseTo(expecSymb.opacity);
-
-          expect(olIcon).toBeDefined();
-        });
-    });
-    it('can write an OpenLayers IconSymbolizer with feature attribute based src', () => {
-      expect.assertions(5);
-      return styleParser.writeStyle(point_dynamic_icon)
-        .then((olStyle: StyleFunction) => {
-          expect(olStyle).toBeDefined();
-          const dummyFeat = new OlFeature({
-            path: 'image.jpg'
-          });
-
-          const styles = olStyle(dummyFeat, 1);
-          expect(styles).toBeDefined();
-          expect(styles).toHaveLength(1);
-
-          const olIcon: OlStyleIcon = styles[0].getImage() as OlStyleIcon;
-          expect(olIcon).toBeDefined();
-          expect(olIcon.getSrc()).toEqual(dummyFeat.get('path'));
-        });
-    });
-    it('can write a OpenLayers RegularShape square', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(point_simplesquare)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simplesquare.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olSquare: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olSquare).toBeDefined();
-
-          expect(olSquare.getPoints()).toBeCloseTo(4);
-          expect(olSquare.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olSquare.getAngle()).toBeCloseTo(45 * Math.PI / 180);
-          expect(olSquare.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olSquareFill: OlStyleFill = olSquare.getFill();
-          expect(olSquareFill).toBeDefined();
-          expect(olSquareFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape star', () => {
-      expect.assertions(9);
-      return styleParser.writeStyle(point_simplestar)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simplestar.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olStar: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olStar).toBeDefined();
-
-          expect(olStar.getPoints()).toBeCloseTo(5);
-          expect(olStar.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olStar.getRadius2()).toBeCloseTo(expecSymb.radius / 2.5);
-          expect(olStar.getAngle()).toBeCloseTo(0);
-          expect(olStar.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olStarFill: OlStyleFill = olStar.getFill();
-          expect(olStarFill).toBeDefined();
-          expect(olStarFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape triangle', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(point_simpletriangle)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simpletriangle.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olTriangle: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olTriangle).toBeDefined();
-
-          expect(olTriangle.getPoints()).toBeCloseTo(3);
-          expect(olTriangle.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olTriangle.getAngle()).toBeCloseTo(0);
-          expect(olTriangle.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olTriangleFill: OlStyleFill = olTriangle.getFill();
-          expect(olTriangleFill).toBeDefined();
-          expect(olTriangleFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape cross', () => {
-      expect.assertions(9);
-      return styleParser.writeStyle(point_simplecross)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simplecross.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olCross: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olCross).toBeDefined();
-
-          expect(olCross.getPoints()).toBeCloseTo(4);
-          expect(olCross.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olCross.getRadius2()).toBeCloseTo(0);
-          expect(olCross.getAngle()).toBeCloseTo(0);
-          expect(olCross.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olCrossFill: OlStyleFill = olCross.getFill();
-          expect(olCrossFill).toBeDefined();
-          expect(olCrossFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape x', () => {
-      expect.assertions(9);
-      return styleParser.writeStyle(point_simplex)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simplex.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olX: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olX).toBeDefined();
-
-          expect(olX.getPoints()).toBeCloseTo(4);
-          expect(olX.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olX.getRadius2()).toBeCloseTo(0);
-          expect(olX.getAngle()).toBeCloseTo(45 * Math.PI / 180);
-          expect(olX.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olXFill: OlStyleFill = olX.getFill();
-          expect(olXFill).toBeDefined();
-          expect(olXFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape shape://slash', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(point_simpleslash)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simpleslash.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olSlash: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olSlash).toBeDefined();
-
-          expect(olSlash.getPoints()).toBeCloseTo(2);
-          expect(olSlash.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olSlash.getAngle()).toBeCloseTo(Math.PI / 4);
-          expect(olSlash.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olSlashFill: OlStyleFill = olSlash.getFill();
-          expect(olSlashFill).toBeDefined();
-          expect(olSlashFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape shape://backslash', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(point_simplebackslash)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simplebackslash.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olBackSlash: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olBackSlash).toBeDefined();
-
-          expect(olBackSlash.getPoints()).toBeCloseTo(2);
-          expect(olBackSlash.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olBackSlash.getAngle()).toBeCloseTo(2 * Math.PI - (Math.PI / 4));
-          expect(olBackSlash.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olBackSlashFill: OlStyleFill = olBackSlash.getFill();
-          expect(olBackSlashFill).toBeDefined();
-          expect(olBackSlashFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape shape://vertline', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(point_simplevertline)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simplevertline.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olVertline: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olVertline).toBeDefined();
-
-          expect(olVertline.getPoints()).toBeCloseTo(2);
-          expect(olVertline.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olVertline.getAngle()).toBeCloseTo(0, 0);
-          expect(olVertline.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olVertlineFill: OlStyleFill = olVertline.getFill();
-          expect(olVertlineFill).toBeDefined();
-          expect(olVertlineFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape shape://horline', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(point_simplehorline)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simplehorline.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olHorline: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olHorline).toBeDefined();
-
-          expect(olHorline.getPoints()).toBeCloseTo(2);
-          expect(olHorline.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olHorline.getAngle()).toBeCloseTo(Math.PI / 2);
-          expect(olHorline.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olHorlineFill: OlStyleFill = olHorline.getFill();
-          expect(olHorlineFill).toBeDefined();
-          expect(olHorlineFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape shape://carrow', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(point_simplecarrow)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simplecarrow.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olCarrow: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olCarrow).toBeDefined();
-
-          expect(olCarrow.getPoints()).toBeCloseTo(3);
-          expect(olCarrow.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olCarrow.getAngle()).toBeCloseTo(Math.PI / 2);
-          expect(olCarrow.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olCarrowFill: OlStyleFill = olCarrow.getFill();
-          expect(olCarrowFill).toBeDefined();
-          expect(olCarrowFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape shape://oarrow', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(point_simpleoarrow)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simpleoarrow.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olOarrow: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olOarrow).toBeDefined();
-
-          expect(olOarrow.getPoints()).toBeCloseTo(3);
-          expect(olOarrow.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olOarrow.getAngle()).toBeCloseTo(Math.PI / 2);
-          expect(olOarrow.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olOarrowFill: OlStyleFill = olOarrow.getFill();
-          expect(olOarrowFill).toBeDefined();
-          expect(olOarrowFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape shape://dot', () => {
-      expect.assertions(4);
-      return styleParser.writeStyle(point_simpledot)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simpledot.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olDot: OlStyleCircle = olStyle.getImage() as OlStyleCircle;
-
-          expect(olDot).toBeDefined();
-          expect(olDot.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olDot.getFill().getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape shape://plus', () => {
-      expect.assertions(9);
-      return styleParser.writeStyle(point_simpleplus)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simpleplus.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olPlus: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olPlus).toBeDefined();
-
-          expect(olPlus.getPoints()).toBeCloseTo(4);
-          expect(olPlus.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olPlus.getRadius2()).toBeCloseTo(0);
-          expect(olPlus.getAngle()).toBeCloseTo(0);
-          expect(olPlus.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olPlusFill: OlStyleFill = olPlus.getFill();
-          expect(olPlusFill).toBeDefined();
-          expect(olPlusFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers RegularShape shape://times', () => {
-      expect.assertions(9);
-      return styleParser.writeStyle(point_simpletimes)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_simpletimes.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olTimes: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
-          expect(olTimes).toBeDefined();
-
-          expect(olTimes.getPoints()).toBeCloseTo(4);
-          expect(olTimes.getRadius()).toBeCloseTo(expecSymb.radius);
-          expect(olTimes.getRadius2()).toBeCloseTo(0);
-          expect(olTimes.getAngle()).toBeCloseTo(45 * Math.PI / 180);
-          expect(olTimes.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olTimesFill: OlStyleFill = olTimes.getFill();
-          expect(olTimesFill).toBeDefined();
-          expect(olTimesFill.getColor()).toEqual(expecSymb.color);
-        });
-    });
-    it('can write a OpenLayers Style based on a font glyph (WellKnownName starts with ttf://)', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(point_fontglyph)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = point_fontglyph.rules[0].symbolizers[0] as MarkSymbolizer;
-          const olText: OlStyleText = olStyle.getText();
-          expect(olText).toBeDefined();
-
-          expect(olText.getFont()).toBe('Normal 12px \'My Font Name\', geostyler-mark-symbolizer');
-          expect(olText.getText()).toBe('|');
-
-          const olTextFill: OlStyleFill = olText.getFill();
-          expect(olTextFill).toBeDefined();
-          expect(olTextFill.getColor()).toEqual(expecSymb.color);
-
-          const olTextStroke: OlStyleStroke = olText.getStroke();
-          expect(olTextStroke).toBeDefined();
-          expect(olTextStroke.getColor()).toEqual(expecSymb.strokeColor);
-        });
-    });
-    it('can write a OpenLayers LineSymbolizer', () => {
-      expect.assertions(5);
-      return styleParser.writeStyle(line_simpleline)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = line_simpleline.rules[0].symbolizers[0] as LineSymbolizer;
-          const olStroke = olStyle.getStroke();
-
-          expect(olStroke).toBeDefined();
-          expect(olStroke.getColor()).toEqual(expecSymb.color);
-          expect(olStroke.getWidth()).toBeCloseTo(expecSymb.width);
-          expect(olStroke.getLineDash()).toEqual(expecSymb.dasharray);
-        });
-    });
-    it('can write a OpenLayers PolygonSymbolizer', () => {
-      expect.assertions(6);
-      return styleParser.writeStyle(polygon_transparentpolygon)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const expecSymb = polygon_transparentpolygon.rules[0].symbolizers[0] as FillSymbolizer;
-          const olStroke = olStyle.getStroke();
-          expect(olStroke).toBeDefined();
-
-          const expecSymbOutlCol: string = expecSymb.outlineColor as string;
-          const expecSymbOutlOpac: number = expecSymb.outlineOpacity as number;
-          expect(olStroke.getColor()).toEqual(OlStyleUtil.getRgbaColor(expecSymbOutlCol, expecSymbOutlOpac));
-
-          const olFill = olStyle.getFill();
-          expect(olFill).toBeDefined();
-
-          const expecSymbFillCol: string = expecSymb.color as string;
-          const expecSymbFillOpac: number = expecSymb.opacity as number;
-          expect(olFill.getColor()).toEqual(OlStyleUtil.getRgbaColor(expecSymbFillCol, expecSymbFillOpac));
-
-          expect(olStroke.getLineDash()).toEqual(expecSymb.outlineDasharray);
-        });
-    });
-    it('can write a OpenLayers PolygonSymbolizer with MarkSymbolizer as graphicFill', () => {
-      expect.assertions(3);
-      return styleParser.writeStyle(polygon_graphicfill_mark)
-        .then((olStyle: OlStyle) => {
-          expect(olStyle).toBeDefined();
-
-          const olFill = olStyle.getFill();
-          expect(olFill).toBeDefined();
-          expect(olFill.getColor()).toBeInstanceOf(CanvasPattern);
-        });
-    });
-    it('can write a OpenLayers TextSymbolizer', () => {
-      expect.assertions(13);
-      return styleParser.writeStyle(point_styledlabel)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const testFeature = new OlFeature({name: 'GeoStyler'});
-          const styles = olStyle(testFeature, 1);
-          expect(styles).toHaveLength(1);
-
-          const expecSymb = point_styledlabel.rules[0].symbolizers[0] as TextSymbolizer;
-
-          const style: OlStyle = styles[0];
-
-          const olText = style.getText();
-          expect(olText).toBeDefined();
-
-          const olTextStroke = olText.getStroke();
-          expect(olTextStroke).toBeDefined();
-          expect(olTextStroke.getColor()).toEqual(expecSymb.haloColor);
-          expect(olTextStroke.getWidth()).toBeCloseTo(expecSymb.haloWidth);
-
-          const olTextFill = olText.getFill();
-          expect(olTextFill).toBeDefined();
-          expect(olTextFill.getColor()).toEqual(expecSymb.color);
-
-          const olTextFont = olText.getFont();
-          expect(olTextFont).toEqual(OlStyleUtil.getTextFont(expecSymb));
-
-          const olTextContent = olText.getText();
-          expect(olTextContent).toEqual(testFeature.get('name'));
-
-          const olTextRotation = olText.getRotation();
-          expect(olTextRotation).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
-
-          const olTextOffsetX = olText.getOffsetX();
-          const olTextOffsetY = olText.getOffsetY();
-          const expectedOffsetX = expecSymb.offset ? expecSymb.offset[0] : null;
-          const expectedOffsetY = expecSymb.offset ? expecSymb.offset[1] : null;
-          expect(olTextOffsetX).toBeCloseTo(expectedOffsetX);
-          expect(olTextOffsetY).toBeCloseTo(expectedOffsetY);
-        });
-    });
-    it('can write an OpenLayers TextSymbolizer with static text', () => {
-      expect.assertions(14);
-      return styleParser.writeStyle(point_styledLabel_static)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const testFeature = new OlFeature();
-          const styles = olStyle(testFeature, 1);
-          expect(styles).toHaveLength(1);
-
-          const expecSymb = point_styledLabel_static.rules[0].symbolizers[0] as TextSymbolizer;
-          const expecText = expecSymb.label;
-          const expecOffset = expecSymb.offset;
-          const expecRotation = expecSymb.rotate * Math.PI / 180;
-          // openlayers adds default font-style
-          const expecFont = `Normal ${expecSymb.size}px ${expecSymb.font.join(', ')}`;
-
-          const style = styles[0] as OlStyle;
-          expect(style).toBeDefined();
-          const olTextStyle = style.getText();
-          expect(olTextStyle).toBeDefined();
-
-          const olText = olTextStyle.getText();
-          expect(olText).toBeDefined();
-          expect(olText).toEqual(expecText);
-
-          const olFont = olTextStyle.getFont();
-          expect(olFont).toBeDefined();
-          expect(olFont).toEqual(expecFont);
-
-          const olRotation = olTextStyle.getRotation();
-          expect(olRotation).toBeDefined();
-          expect(olRotation).toBeCloseTo(expecRotation);
-
-          const olOffsetX = olTextStyle.getOffsetX();
-          expect(olOffsetX).toBeDefined();
-          expect(olOffsetX).toBeCloseTo(expecOffset[0]);
-
-          const olOffsetY = olTextStyle.getOffsetY();
-          expect(olOffsetY).toBeDefined();
-          expect(olOffsetY).toBeCloseTo(expecOffset[1]);
-        });
-    });
-    it('can write an OpenLayers Style from multiple symbolizers in one Rule', () => {
-      expect.assertions(7);
-      return styleParser.writeStyle(multi_simplefillSimpleline)
-        .then((olStyles: OlStyle[]) => {
-          expect(olStyles).toBeDefined();
-          expect(olStyles).toHaveLength(2);
-
-          const expecFill = multi_simplefillSimpleline.rules[0].symbolizers[0] as FillSymbolizer;
-          const expecLine = multi_simplefillSimpleline.rules[0].symbolizers[1] as LineSymbolizer;
-
-          const olFill = olStyles[0].getFill();
-          expect(olFill).toBeDefined();
-
-          expect(olFill.getColor()).toEqual(expecFill.color);
-
-          const olLine = olStyles[1].getStroke();
-          expect(olLine).toBeDefined();
-
-          expect(olLine.getColor()).toEqual(expecLine.color);
-          expect(olLine.getWidth()).toBeCloseTo(expecLine.width);
-        });
-    });
-    it('can write an OpenLayers Style from symbolizers in multiple Rules', () => {
-      expect.assertions(8);
-      return styleParser.writeStyle(multi_twoRulesSimplepoint)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const testFeature = new OlFeature();
-          const styles = olStyle(testFeature, 1);
-          expect(styles).toHaveLength(2);
-
-          const expecSymb1 = multi_twoRulesSimplepoint.rules[0].symbolizers[0] as MarkSymbolizer;
-          const expecSymb2 = multi_twoRulesSimplepoint.rules[1].symbolizers[0] as MarkSymbolizer;
-
-          const olCircle1 = styles[0].getImage() as OlStyleCircle;
-          expect(olCircle1).toBeDefined();
-          expect(olCircle1.getRadius()).toBeCloseTo(expecSymb1.radius);
-          expect(olCircle1.getFill().getColor()).toEqual(expecSymb1.color);
-
-          const olCircle2 = styles[1].getImage() as OlStyleCircle;
-          expect(olCircle2).toBeDefined();
-          expect(olCircle2.getRadius()).toBeCloseTo(expecSymb2.radius);
-          expect(olCircle2.getFill().getColor()).toEqual(expecSymb2.color);
-        });
-    });
-    it('transforms labels values based on fields to string ', () => {
-      expect.assertions(5);
-      // change the field as base for the label text to a numeric one
-      const inSymb = point_styledlabel.rules[0].symbolizers[0] as TextSymbolizer;
-      inSymb.label = '{{id}}';
-      return styleParser.writeStyle(point_styledlabel)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const dummyFeat = new OlFeature({
-            id: 1
-          });
-
-          const styles = olStyle(dummyFeat, 1);
-          expect(styles).toBeDefined();
-          expect(styles).toHaveLength(1);
-
-          const olText = styles[0].getText();
-          const olTextContent = olText.getText();
-          expect(typeof olTextContent).toEqual('string');
-          expect(olTextContent).toEqual(dummyFeat.get('id') + '');
-
-        });
-    });
-    it('returns style if scale is within scaleDenominators', () => {
-      expect.assertions(3);
-      return styleParser.writeStyle(scaleDenomLine)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const withinScale: number = scaleDenomLine.rules[0].scaleDenominator.min;
-          const beyondScale: number = scaleDenomLine.rules[0].scaleDenominator.max;
-
-          const resolutionRuleOne = MapUtil.getResolutionForScale(withinScale, 'm');
-          const resolutionRuleTwo = MapUtil.getResolutionForScale(beyondScale, 'm');
-
-          const dummyFeat = new OlFeature();
-          const styleWithinScale = olStyle(dummyFeat, resolutionRuleOne);
-          const styleBeyondScale = olStyle(dummyFeat, resolutionRuleTwo);
-
-          expect(styleWithinScale).toHaveLength(1);
-          expect(styleBeyondScale).toHaveLength(0);
-        });
-    });
-    it('returns right style based on scaleDenominators', () => {
-      expect.assertions(11);
-      return styleParser.writeStyle(scaleDenomLineCircle)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const scaleWithinFirst: number = scaleDenomLineCircle.rules[0].scaleDenominator.min;
-          const scaleWithinSecond: number = scaleDenomLineCircle.rules[1].scaleDenominator.min;
-          const scaleBeyond: number = scaleDenomLineCircle.rules[1].scaleDenominator.max;
-
-          const resolutionWithinFirst = MapUtil.getResolutionForScale(scaleWithinFirst, 'm');
-          const resolutionWithinSecond = MapUtil.getResolutionForScale(scaleWithinSecond, 'm');
-          const resolutionBeyond = MapUtil.getResolutionForScale(scaleBeyond, 'm');
-
-          const dummyFeat = new OlFeature();
-          const styleWithinFirst = olStyle(dummyFeat, resolutionWithinFirst);
-          const styleWithinSecond = olStyle(dummyFeat, resolutionWithinSecond);
-          const styleBeyond = olStyle(dummyFeat, resolutionBeyond);
-
-          expect(styleWithinFirst).toHaveLength(1);
-          expect(styleWithinSecond).toHaveLength(1);
-          expect(styleBeyond).toHaveLength(0);
-
-          const styleFirst: OlStyle = styleWithinFirst[0];
-          const expecFirst = scaleDenomLineCircle.rules[0].symbolizers[0] as LineSymbolizer;
-          const olStroke = styleFirst.getStroke();
-          expect(olStroke).toBeDefined();
-          expect(olStroke.getColor()).toEqual(expecFirst.color);
-          expect(olStroke.getWidth()).toBeCloseTo(expecFirst.width);
-          expect(olStroke.getLineDash()).toEqual(expecFirst.dasharray);
-
-          const styleSecond: OlStyle = styleWithinSecond[0];
-          const expecSecond = scaleDenomLineCircle.rules[1].symbolizers[0] as MarkSymbolizer;
-          const olCircle: OlStyleCircle = styleSecond.getImage() as OlStyleCircle;
-          expect(olCircle).toBeDefined();
-          expect(olCircle.getRadius()).toBeCloseTo(expecSecond.radius);
-          expect(olCircle.getFill().getColor()).toEqual(expecSecond.color);
-        });
-    });
-    it('returns styles of all rules that lie within scaleDenominator', () => {
-      expect.assertions(4);
-      return styleParser.writeStyle(scaleDenomLineCircleOverlap)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const scaleOnlyFirst: number = scaleDenomLineCircleOverlap.rules[0].scaleDenominator.min;
-          const scaleOverlap: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.min;
-          const scaleOnlySecond: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.max - 1;
-
-          const resolutionOnlyFirst = MapUtil.getResolutionForScale(scaleOnlyFirst, 'm');
-          const resolutionOverlap = MapUtil.getResolutionForScale(scaleOverlap, 'm');
-          const resolutionOnlySecond = MapUtil.getResolutionForScale(scaleOnlySecond, 'm');
-
-          const dummyFeat = new OlFeature();
-          const styleOnlyFirst = olStyle(dummyFeat, resolutionOnlyFirst);
-          const styleOverlap = olStyle(dummyFeat, resolutionOverlap);
-          const styleOnlySecond = olStyle(dummyFeat, resolutionOnlySecond);
-
-          expect(styleOnlyFirst).toHaveLength(1);
-          expect(styleOverlap).toHaveLength(2);
-          expect(styleOnlySecond).toHaveLength(1);
-        });
-    });
-    it('can write an OpenLayers style with a simple filter', () => {
-      expect.assertions(5);
-      return styleParser.writeStyle(filter_simplefilter)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const bonnFeat = new OlFeature();
-          bonnFeat.set('Name', 'Bonn');
-          const bonnStyle = olStyle(bonnFeat, 1);
-          expect(bonnStyle).toBeDefined();
-          const bonnRadius = bonnStyle[0].getImage().getRadius();
-          const expecBonnSymbolizer: MarkSymbolizer = filter_simplefilter.rules[0].symbolizers[0] as MarkSymbolizer;
-          expect(bonnRadius).toBeCloseTo(expecBonnSymbolizer.radius);
-
-          const notBonnFeat = new OlFeature();
-          notBonnFeat.set('Name', 'Koblenz');
-          const notBonnStyle = olStyle(notBonnFeat, 1);
-          expect(notBonnStyle).toBeDefined();
-          const notBonnRadius = notBonnStyle[0].getImage().getRadius();
-          const expecNotBonnSymbolizer: MarkSymbolizer = filter_simplefilter.rules[1].symbolizers[0] as MarkSymbolizer;
-          expect(notBonnRadius).toBeCloseTo(expecNotBonnSymbolizer.radius);
-        });
-    });
-    it('can write an OpenLayers style with a nested filter', () => {
-      expect.assertions(7);
-      return styleParser.writeStyle(filter_nestedfilter)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const matchFilterFeat = new OlFeature();
-          matchFilterFeat.set('state', 'germany');
-          matchFilterFeat.set('population', 100000);
-          matchFilterFeat.set('name', 'Dortmund');
-          const matchStyle = olStyle(matchFilterFeat, 1);
-          expect(matchStyle).toBeDefined();
-          const matchRadius = matchStyle[0].getImage().getRadius();
-          const expecMatchSymbolizer: MarkSymbolizer = filter_nestedfilter.rules[0].symbolizers[0] as MarkSymbolizer;
-          expect(matchRadius).toBeCloseTo(expecMatchSymbolizer.radius);
-
-          const noMatchFilterFeat = new OlFeature();
-          noMatchFilterFeat.set('state', 'germany');
-          noMatchFilterFeat.set('population', 100000);
-          noMatchFilterFeat.set('name', 'Schalke');
-          const noMatchStyle = olStyle(noMatchFilterFeat, 1);
-          expect(noMatchStyle).toBeDefined();
-          const noMatchRadius = noMatchStyle[0].getImage().getRadius();
-          const expecNoMatchSymbolizer: MarkSymbolizer = filter_nestedfilter.rules[1].symbolizers[0] as MarkSymbolizer;
-          expect(noMatchRadius).toBeCloseTo(expecNoMatchSymbolizer.radius);
-
-          const noMatchFilterFeat2 = new OlFeature();
-          noMatchFilterFeat2.set('state', 'germany');
-          noMatchFilterFeat2.set('population', '100000');
-          noMatchFilterFeat2.set('name', 'Schalke');
-          const noMatchStyle2 = olStyle(noMatchFilterFeat2, 1);
-          expect(noMatchStyle2).toBeDefined();
-          const noMatchRadius2 = noMatchStyle2[0].getImage().getRadius();
-          const expecNoMatch2Symbolizer: MarkSymbolizer = filter_nestedfilter.rules[1].symbolizers[0] as MarkSymbolizer;
-          expect(noMatchRadius2).toBeCloseTo(expecNoMatch2Symbolizer.radius);
-        });
-    });
-    it('does neither match nor crash if filters are invalid', () => {
-      expect.assertions(3);
-      return styleParser.writeStyle(filter_invalidfilter)
-        .then((olStyle: OlParserStyleFct) => {
-          expect(olStyle).toBeDefined();
-
-          const noMatchFilterFeat = new OlFeature();
-          noMatchFilterFeat.set('state', 'germany');
-          noMatchFilterFeat.set('population', 100000);
-          noMatchFilterFeat.set('name', 'Schalke');
-          const noMatchStyle = olStyle(noMatchFilterFeat, 1);
-          expect(noMatchStyle).toBeDefined();
-          const noMatchRadius = noMatchStyle[0].getImage().getRadius();
-          const expecNoMatchSymbolizer: MarkSymbolizer = filter_invalidfilter.rules[1].symbolizers[0] as MarkSymbolizer;
-          expect(noMatchRadius).toBeCloseTo(expecNoMatchSymbolizer.radius);
-        });
+  });
+  it('can write a OpenLayers RegularShape square', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simplesquare);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simplesquare.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olSquare: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olSquare).toBeDefined();
+
+    expect(olSquare.getPoints()).toBeCloseTo(4);
+    expect(olSquare.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olSquare.getAngle()).toBeCloseTo(45 * Math.PI / 180);
+    expect(olSquare.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olSquareFill: OlStyleFill = olSquare.getFill();
+    expect(olSquareFill).toBeDefined();
+    expect(olSquareFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape star', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simplestar);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simplestar.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olStar: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olStar).toBeDefined();
+
+    expect(olStar.getPoints()).toBeCloseTo(5);
+    expect(olStar.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olStar.getRadius2()).toBeCloseTo(expecSymb.radius / 2.5);
+    expect(olStar.getAngle()).toBeCloseTo(0);
+    expect(olStar.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olStarFill: OlStyleFill = olStar.getFill();
+    expect(olStarFill).toBeDefined();
+    expect(olStarFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape triangle', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simpletriangle);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simpletriangle.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olTriangle: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olTriangle).toBeDefined();
+
+    expect(olTriangle.getPoints()).toBeCloseTo(3);
+    expect(olTriangle.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olTriangle.getAngle()).toBeCloseTo(0);
+    expect(olTriangle.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olTriangleFill: OlStyleFill = olTriangle.getFill();
+    expect(olTriangleFill).toBeDefined();
+    expect(olTriangleFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape cross', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simplecross);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simplecross.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olCross: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olCross).toBeDefined();
+
+    expect(olCross.getPoints()).toBeCloseTo(4);
+    expect(olCross.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olCross.getRadius2()).toBeCloseTo(0);
+    expect(olCross.getAngle()).toBeCloseTo(0);
+    expect(olCross.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olCrossFill: OlStyleFill = olCross.getFill();
+    expect(olCrossFill).toBeDefined();
+    expect(olCrossFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape x', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simplex);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simplex.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olX: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olX).toBeDefined();
+
+    expect(olX.getPoints()).toBeCloseTo(4);
+    expect(olX.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olX.getRadius2()).toBeCloseTo(0);
+    expect(olX.getAngle()).toBeCloseTo(45 * Math.PI / 180);
+    expect(olX.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olXFill: OlStyleFill = olX.getFill();
+    expect(olXFill).toBeDefined();
+    expect(olXFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape shape://slash', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simpleslash);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simpleslash.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olSlash: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olSlash).toBeDefined();
+
+    expect(olSlash.getPoints()).toBeCloseTo(2);
+    expect(olSlash.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olSlash.getAngle()).toBeCloseTo(Math.PI / 4);
+    expect(olSlash.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olSlashFill: OlStyleFill = olSlash.getFill();
+    expect(olSlashFill).toBeDefined();
+    expect(olSlashFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape shape://backslash', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simplebackslash);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simplebackslash.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olBackSlash: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olBackSlash).toBeDefined();
+
+    expect(olBackSlash.getPoints()).toBeCloseTo(2);
+    expect(olBackSlash.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olBackSlash.getAngle()).toBeCloseTo(2 * Math.PI - (Math.PI / 4));
+    expect(olBackSlash.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olBackSlashFill: OlStyleFill = olBackSlash.getFill();
+    expect(olBackSlashFill).toBeDefined();
+    expect(olBackSlashFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape shape://vertline', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simplevertline);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simplevertline.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olVertline: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olVertline).toBeDefined();
+
+    expect(olVertline.getPoints()).toBeCloseTo(2);
+    expect(olVertline.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olVertline.getAngle()).toBeCloseTo(0, 0);
+    expect(olVertline.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olVertlineFill: OlStyleFill = olVertline.getFill();
+    expect(olVertlineFill).toBeDefined();
+    expect(olVertlineFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape shape://horline', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simplehorline);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simplehorline.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olHorline: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olHorline).toBeDefined();
+
+    expect(olHorline.getPoints()).toBeCloseTo(2);
+    expect(olHorline.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olHorline.getAngle()).toBeCloseTo(Math.PI / 2);
+    expect(olHorline.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olHorlineFill: OlStyleFill = olHorline.getFill();
+    expect(olHorlineFill).toBeDefined();
+    expect(olHorlineFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape shape://carrow', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simplecarrow);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simplecarrow.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olCarrow: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olCarrow).toBeDefined();
+
+    expect(olCarrow.getPoints()).toBeCloseTo(3);
+    expect(olCarrow.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olCarrow.getAngle()).toBeCloseTo(Math.PI / 2);
+    expect(olCarrow.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olCarrowFill: OlStyleFill = olCarrow.getFill();
+    expect(olCarrowFill).toBeDefined();
+    expect(olCarrowFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape shape://oarrow', async() => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simpleoarrow);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simpleoarrow.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olOarrow: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olOarrow).toBeDefined();
+
+    expect(olOarrow.getPoints()).toBeCloseTo(3);
+    expect(olOarrow.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olOarrow.getAngle()).toBeCloseTo(Math.PI / 2);
+    expect(olOarrow.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olOarrowFill: OlStyleFill = olOarrow.getFill();
+    expect(olOarrowFill).toBeDefined();
+    expect(olOarrowFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape shape://dot', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simpledot);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simpledot.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olDot: OlStyleCircle = olStyle.getImage() as OlStyleCircle;
+
+    expect(olDot).toBeDefined();
+    expect(olDot.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olDot.getFill().getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape shape://plus', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simpleplus);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simpleplus.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olPlus: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olPlus).toBeDefined();
+
+    expect(olPlus.getPoints()).toBeCloseTo(4);
+    expect(olPlus.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olPlus.getRadius2()).toBeCloseTo(0);
+    expect(olPlus.getAngle()).toBeCloseTo(0);
+    expect(olPlus.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olPlusFill: OlStyleFill = olPlus.getFill();
+    expect(olPlusFill).toBeDefined();
+    expect(olPlusFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers RegularShape shape://times', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_simpletimes);
+
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_simpletimes.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olTimes: OlStyleRegularshape = olStyle.getImage() as OlStyleRegularshape;
+    expect(olTimes).toBeDefined();
+
+    expect(olTimes.getPoints()).toBeCloseTo(4);
+    expect(olTimes.getRadius()).toBeCloseTo(expecSymb.radius);
+    expect(olTimes.getRadius2()).toBeCloseTo(0);
+    expect(olTimes.getAngle()).toBeCloseTo(45 * Math.PI / 180);
+    expect(olTimes.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olTimesFill: OlStyleFill = olTimes.getFill();
+    expect(olTimesFill).toBeDefined();
+    expect(olTimesFill.getColor()).toEqual(expecSymb.color);
+  });
+  it('can write a OpenLayers Style based on a font glyph (WellKnownName starts with ttf://)', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_fontglyph);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = point_fontglyph.rules[0].symbolizers[0] as MarkSymbolizer;
+    const olText: OlStyleText = olStyle.getText();
+    expect(olText).toBeDefined();
+
+    expect(olText.getFont()).toBe('Normal 12px \'My Font Name\', geostyler-mark-symbolizer');
+    expect(olText.getText()).toBe('|');
+
+    const olTextFill: OlStyleFill = olText.getFill();
+    expect(olTextFill).toBeDefined();
+    expect(olTextFill.getColor()).toEqual(expecSymb.color);
+
+    const olTextStroke: OlStyleStroke = olText.getStroke();
+    expect(olTextStroke).toBeDefined();
+    expect(olTextStroke.getColor()).toEqual(expecSymb.strokeColor);
+  });
+  it('can write a OpenLayers LineSymbolizer', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(line_simpleline);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = line_simpleline.rules[0].symbolizers[0] as LineSymbolizer;
+    const olStroke = olStyle.getStroke();
+
+    expect(olStroke).toBeDefined();
+    expect(olStroke.getColor()).toEqual(expecSymb.color);
+    expect(olStroke.getWidth()).toBeCloseTo(expecSymb.width);
+    expect(olStroke.getLineDash()).toEqual(expecSymb.dasharray);
+  });
+  it('can write a OpenLayers PolygonSymbolizer', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(polygon_transparentpolygon);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const expecSymb = polygon_transparentpolygon.rules[0].symbolizers[0] as FillSymbolizer;
+    const olStroke = olStyle.getStroke();
+    expect(olStroke).toBeDefined();
+
+    const expecSymbOutlCol: string = expecSymb.outlineColor as string;
+    const expecSymbOutlOpac: number = expecSymb.outlineOpacity as number;
+    expect(olStroke.getColor()).toEqual(OlStyleUtil.getRgbaColor(expecSymbOutlCol, expecSymbOutlOpac));
+
+    const olFill = olStyle.getFill();
+    expect(olFill).toBeDefined();
+
+    const expecSymbFillCol: string = expecSymb.color as string;
+    const expecSymbFillOpac: number = expecSymb.opacity as number;
+    expect(olFill.getColor()).toEqual(OlStyleUtil.getRgbaColor(expecSymbFillCol, expecSymbFillOpac));
+
+    expect(olStroke.getLineDash()).toEqual(expecSymb.outlineDasharray);
+  });
+  it('can write a OpenLayers PolygonSymbolizer with MarkSymbolizer as graphicFill', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(polygon_graphicfill_mark);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const olFill = olStyle.getFill();
+    expect(olFill).toBeDefined();
+    expect(olFill.getColor()).toBeInstanceOf(CanvasPattern);
+  });
+  it('can write a OpenLayers TextSymbolizer', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_styledlabel);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const testFeature = new OlFeature({name: 'GeoStyler'});
+    const styles = olStyle(testFeature, 1);
+    expect(styles).toHaveLength(1);
+
+    const expecSymb = point_styledlabel.rules[0].symbolizers[0] as TextSymbolizer;
+
+    const style: OlStyle = styles[0];
+
+    const olText = style.getText();
+    expect(olText).toBeDefined();
+
+    const olTextStroke = olText.getStroke();
+    expect(olTextStroke).toBeDefined();
+    expect(olTextStroke.getColor()).toEqual(expecSymb.haloColor);
+    expect(olTextStroke.getWidth()).toBeCloseTo(expecSymb.haloWidth);
+
+    const olTextFill = olText.getFill();
+    expect(olTextFill).toBeDefined();
+    expect(olTextFill.getColor()).toEqual(expecSymb.color);
+
+    const olTextFont = olText.getFont();
+    expect(olTextFont).toEqual(OlStyleUtil.getTextFont(expecSymb));
+
+    const olTextContent = olText.getText();
+    expect(olTextContent).toEqual(testFeature.get('name'));
+
+    const olTextRotation = olText.getRotation();
+    expect(olTextRotation).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
+
+    const olTextOffsetX = olText.getOffsetX();
+    const olTextOffsetY = olText.getOffsetY();
+    const expectedOffsetX = expecSymb.offset ? expecSymb.offset[0] : null;
+    const expectedOffsetY = expecSymb.offset ? expecSymb.offset[1] : null;
+    expect(olTextOffsetX).toBeCloseTo(expectedOffsetX);
+    expect(olTextOffsetY).toBeCloseTo(expectedOffsetY);
+  });
+  it('can write an OpenLayers TextSymbolizer with static text', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(point_styledLabel_static);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const testFeature = new OlFeature();
+    const styles = olStyle(testFeature, 1);
+    expect(styles).toHaveLength(1);
+
+    const expecSymb = point_styledLabel_static.rules[0].symbolizers[0] as TextSymbolizer;
+    const expecText = expecSymb.label;
+    const expecOffset = expecSymb.offset;
+    const expecRotation = expecSymb.rotate * Math.PI / 180;
+    // openlayers adds default font-style
+    const expecFont = `Normal ${expecSymb.size}px ${expecSymb.font.join(', ')}`;
+
+    const style = styles[0] as OlStyle;
+    expect(style).toBeDefined();
+    const olTextStyle = style.getText();
+    expect(olTextStyle).toBeDefined();
+
+    const olText = olTextStyle.getText();
+    expect(olText).toBeDefined();
+    expect(olText).toEqual(expecText);
+
+    const olFont = olTextStyle.getFont();
+    expect(olFont).toBeDefined();
+    expect(olFont).toEqual(expecFont);
+
+    const olRotation = olTextStyle.getRotation();
+    expect(olRotation).toBeDefined();
+    expect(olRotation).toBeCloseTo(expecRotation);
+
+    const olOffsetX = olTextStyle.getOffsetX();
+    expect(olOffsetX).toBeDefined();
+    expect(olOffsetX).toBeCloseTo(expecOffset[0]);
+
+    const olOffsetY = olTextStyle.getOffsetY();
+    expect(olOffsetY).toBeDefined();
+    expect(olOffsetY).toBeCloseTo(expecOffset[1]);
+  });
+  it('can write an OpenLayers Style from multiple symbolizers in one Rule', async () => {
+    const { output: olStyles } = await styleParser.writeStyle(multi_simplefillSimpleline);
+    expect(olStyles).toBeDefined();
+    expect(olStyles).toHaveLength(2);
+
+    const expecFill = multi_simplefillSimpleline.rules[0].symbolizers[0] as FillSymbolizer;
+    const expecLine = multi_simplefillSimpleline.rules[0].symbolizers[1] as LineSymbolizer;
+
+    const olFill = olStyles[0].getFill();
+    expect(olFill).toBeDefined();
+
+    expect(olFill.getColor()).toEqual(expecFill.color);
+
+    const olLine = olStyles[1].getStroke();
+    expect(olLine).toBeDefined();
+
+    expect(olLine.getColor()).toEqual(expecLine.color);
+    expect(olLine.getWidth()).toBeCloseTo(expecLine.width);
+  });
+  it('can write an OpenLayers Style from symbolizers in multiple Rules', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(multi_twoRulesSimplepoint);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const testFeature = new OlFeature();
+    const styles = olStyle(testFeature, 1);
+    expect(styles).toHaveLength(2);
+
+    const expecSymb1 = multi_twoRulesSimplepoint.rules[0].symbolizers[0] as MarkSymbolizer;
+    const expecSymb2 = multi_twoRulesSimplepoint.rules[1].symbolizers[0] as MarkSymbolizer;
+
+    const olCircle1 = styles[0].getImage() as OlStyleCircle;
+    expect(olCircle1).toBeDefined();
+    expect(olCircle1.getRadius()).toBeCloseTo(expecSymb1.radius);
+    expect(olCircle1.getFill().getColor()).toEqual(expecSymb1.color);
+
+    const olCircle2 = styles[1].getImage() as OlStyleCircle;
+    expect(olCircle2).toBeDefined();
+    expect(olCircle2.getRadius()).toBeCloseTo(expecSymb2.radius);
+    expect(olCircle2.getFill().getColor()).toEqual(expecSymb2.color);
+  });
+  it('transforms labels values based on fields to string ', async () => {
+    // change the field as base for the label text to a numeric one
+    const inSymb = point_styledlabel.rules[0].symbolizers[0] as TextSymbolizer;
+    inSymb.label = '{{id}}';
+    let { output: olStyle } = await styleParser.writeStyle(point_styledlabel);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const dummyFeat = new OlFeature({
+      id: 1
     });
 
-    describe('#getOlStyleTypeFromGeoStylerStyle', () => {
-      it('is defined', () => {
-        expect(styleParser.getOlStyleTypeFromGeoStylerStyle).toBeDefined();
-      });
-    });
+    const styles = olStyle(dummyFeat, 1);
+    expect(styles).toBeDefined();
+    expect(styles).toHaveLength(1);
 
-    describe('#geoStylerStyleToOlStyle', () => {
-      it('is defined', () => {
-        expect(styleParser.geoStylerStyleToOlStyle).toBeDefined();
-      });
-    });
-
-    describe('#geoStylerStyleToOlStyleArray', () => {
-      it('is defined', () => {
-        expect(styleParser.geoStylerStyleToOlStyleArray).toBeDefined();
-      });
-    });
-
-    describe('#geoStylerStyleToOlParserStyleFct', () => {
-      it('is defined', () => {
-        expect(styleParser.geoStylerStyleToOlParserStyleFct).toBeDefined();
-      });
-    });
-
-    describe('#geoStylerFilterToOlParserFilter', () => {
-      it('is defined', () => {
-        expect(styleParser.geoStylerFilterToOlParserFilter).toBeDefined();
-      });
-    });
-
-    describe('#getOlSymbolizerFromSymbolizer', () => {
-      it('is defined', () => {
-        expect(styleParser.getOlSymbolizerFromSymbolizer).toBeDefined();
-      });
-    });
-
-    describe('#getOlPointSymbolizerFromMarkSymbolizer', () => {
-      it('is defined', () => {
-        expect(styleParser.getOlPointSymbolizerFromMarkSymbolizer).toBeDefined();
-      });
-    });
-
-    describe('#getOlIconSymbolizerFromIconSymbolizer', () => {
-      it('is defined', () => {
-        expect(styleParser.getOlIconSymbolizerFromIconSymbolizer).toBeDefined();
-      });
-    });
-
-    describe('#getOlTextSymbolizerFromTextSymbolizer', () => {
-      it('is defined', () => {
-        expect(styleParser.getOlTextSymbolizerFromTextSymbolizer).toBeDefined();
-      });
-    });
-
-    describe('#getOlPolygonSymbolizerFromFillSymbolizer', () => {
-      it('is defined', () => {
-        expect(styleParser.getOlPolygonSymbolizerFromFillSymbolizer).toBeDefined();
-      });
-    });
-
-    describe('#getOlLineSymbolizerFromLineSymbolizer', () => {
-      it('is defined', () => {
-        expect(styleParser.getOlLineSymbolizerFromLineSymbolizer).toBeDefined();
-      });
-    });
-
-    // describe('#getSldComparisonFilterFromComparisonFilte', () => {
-    //   it('is defined', () => {
-    //     expect(styleParser.getSldComparisonFilterFromComparisonFilter).toBeDefined();
-    //   });
-    // });
-
-    // describe('#getSldFilterFromFilter', () => {
-    //   it('is defined', () => {
-    //     expect(styleParser.getSldFilterFromFilter).toBeDefined();
-    //   });
-    // });
+    const olText = styles[0].getText();
+    const olTextContent = olText.getText();
+    expect(typeof olTextContent).toEqual('string');
+    expect(olTextContent).toEqual(dummyFeat.get('id') + '');
 
   });
+  it('returns style if scale is within scaleDenominators', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(scaleDenomLine);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const withinScale: number = scaleDenomLine.rules[0].scaleDenominator.min;
+    const beyondScale: number = scaleDenomLine.rules[0].scaleDenominator.max;
+
+    const resolutionRuleOne = MapUtil.getResolutionForScale(withinScale, 'm');
+    const resolutionRuleTwo = MapUtil.getResolutionForScale(beyondScale, 'm');
+
+    const dummyFeat = new OlFeature();
+    const styleWithinScale = olStyle(dummyFeat, resolutionRuleOne);
+    const styleBeyondScale = olStyle(dummyFeat, resolutionRuleTwo);
+
+    expect(styleWithinScale).toHaveLength(1);
+    expect(styleBeyondScale).toHaveLength(0);
+  });
+  it('returns right style based on scaleDenominators', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(scaleDenomLineCircle);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const scaleWithinFirst: number = scaleDenomLineCircle.rules[0].scaleDenominator.min;
+    const scaleWithinSecond: number = scaleDenomLineCircle.rules[1].scaleDenominator.min;
+    const scaleBeyond: number = scaleDenomLineCircle.rules[1].scaleDenominator.max;
+
+    const resolutionWithinFirst = MapUtil.getResolutionForScale(scaleWithinFirst, 'm');
+    const resolutionWithinSecond = MapUtil.getResolutionForScale(scaleWithinSecond, 'm');
+    const resolutionBeyond = MapUtil.getResolutionForScale(scaleBeyond, 'm');
+
+    const dummyFeat = new OlFeature();
+    const styleWithinFirst = olStyle(dummyFeat, resolutionWithinFirst);
+    const styleWithinSecond = olStyle(dummyFeat, resolutionWithinSecond);
+    const styleBeyond = olStyle(dummyFeat, resolutionBeyond);
+
+    expect(styleWithinFirst).toHaveLength(1);
+    expect(styleWithinSecond).toHaveLength(1);
+    expect(styleBeyond).toHaveLength(0);
+
+    const styleFirst: OlStyle = styleWithinFirst[0];
+    const expecFirst = scaleDenomLineCircle.rules[0].symbolizers[0] as LineSymbolizer;
+    const olStroke = styleFirst.getStroke();
+    expect(olStroke).toBeDefined();
+    expect(olStroke.getColor()).toEqual(expecFirst.color);
+    expect(olStroke.getWidth()).toBeCloseTo(expecFirst.width);
+    expect(olStroke.getLineDash()).toEqual(expecFirst.dasharray);
+
+    const styleSecond: OlStyle = styleWithinSecond[0];
+    const expecSecond = scaleDenomLineCircle.rules[1].symbolizers[0] as MarkSymbolizer;
+    const olCircle: OlStyleCircle = styleSecond.getImage() as OlStyleCircle;
+    expect(olCircle).toBeDefined();
+    expect(olCircle.getRadius()).toBeCloseTo(expecSecond.radius);
+    expect(olCircle.getFill().getColor()).toEqual(expecSecond.color);
+  });
+  it('returns styles of all rules that lie within scaleDenominator', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(scaleDenomLineCircleOverlap);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const scaleOnlyFirst: number = scaleDenomLineCircleOverlap.rules[0].scaleDenominator.min;
+    const scaleOverlap: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.min;
+    const scaleOnlySecond: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.max - 1;
+
+    const resolutionOnlyFirst = MapUtil.getResolutionForScale(scaleOnlyFirst, 'm');
+    const resolutionOverlap = MapUtil.getResolutionForScale(scaleOverlap, 'm');
+    const resolutionOnlySecond = MapUtil.getResolutionForScale(scaleOnlySecond, 'm');
+
+    const dummyFeat = new OlFeature();
+    const styleOnlyFirst = olStyle(dummyFeat, resolutionOnlyFirst);
+    const styleOverlap = olStyle(dummyFeat, resolutionOverlap);
+    const styleOnlySecond = olStyle(dummyFeat, resolutionOnlySecond);
+
+    expect(styleOnlyFirst).toHaveLength(1);
+    expect(styleOverlap).toHaveLength(2);
+    expect(styleOnlySecond).toHaveLength(1);
+  });
+  it('can write an OpenLayers style with a simple filter', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(filter_simplefilter);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const bonnFeat = new OlFeature();
+    bonnFeat.set('Name', 'Bonn');
+    const bonnStyle = olStyle(bonnFeat, 1);
+    expect(bonnStyle).toBeDefined();
+    const bonnRadius = bonnStyle[0].getImage().getRadius();
+    const expecBonnSymbolizer: MarkSymbolizer = filter_simplefilter.rules[0].symbolizers[0] as MarkSymbolizer;
+    expect(bonnRadius).toBeCloseTo(expecBonnSymbolizer.radius);
+
+    const notBonnFeat = new OlFeature();
+    notBonnFeat.set('Name', 'Koblenz');
+    const notBonnStyle = olStyle(notBonnFeat, 1);
+    expect(notBonnStyle).toBeDefined();
+    const notBonnRadius = notBonnStyle[0].getImage().getRadius();
+    const expecNotBonnSymbolizer: MarkSymbolizer = filter_simplefilter.rules[1].symbolizers[0] as MarkSymbolizer;
+    expect(notBonnRadius).toBeCloseTo(expecNotBonnSymbolizer.radius);
+  });
+  it('can write an OpenLayers style with a nested filter', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(filter_nestedfilter);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const matchFilterFeat = new OlFeature();
+    matchFilterFeat.set('state', 'germany');
+    matchFilterFeat.set('population', 100000);
+    matchFilterFeat.set('name', 'Dortmund');
+    const matchStyle = olStyle(matchFilterFeat, 1);
+    expect(matchStyle).toBeDefined();
+    const matchRadius = matchStyle[0].getImage().getRadius();
+    const expecMatchSymbolizer: MarkSymbolizer = filter_nestedfilter.rules[0].symbolizers[0] as MarkSymbolizer;
+    expect(matchRadius).toBeCloseTo(expecMatchSymbolizer.radius);
+
+    const noMatchFilterFeat = new OlFeature();
+    noMatchFilterFeat.set('state', 'germany');
+    noMatchFilterFeat.set('population', 100000);
+    noMatchFilterFeat.set('name', 'Schalke');
+    const noMatchStyle = olStyle(noMatchFilterFeat, 1);
+    expect(noMatchStyle).toBeDefined();
+    const noMatchRadius = noMatchStyle[0].getImage().getRadius();
+    const expecNoMatchSymbolizer: MarkSymbolizer = filter_nestedfilter.rules[1].symbolizers[0] as MarkSymbolizer;
+    expect(noMatchRadius).toBeCloseTo(expecNoMatchSymbolizer.radius);
+
+    const noMatchFilterFeat2 = new OlFeature();
+    noMatchFilterFeat2.set('state', 'germany');
+    noMatchFilterFeat2.set('population', '100000');
+    noMatchFilterFeat2.set('name', 'Schalke');
+    const noMatchStyle2 = olStyle(noMatchFilterFeat2, 1);
+    expect(noMatchStyle2).toBeDefined();
+    const noMatchRadius2 = noMatchStyle2[0].getImage().getRadius();
+    const expecNoMatch2Symbolizer: MarkSymbolizer = filter_nestedfilter.rules[1].symbolizers[0] as MarkSymbolizer;
+    expect(noMatchRadius2).toBeCloseTo(expecNoMatch2Symbolizer.radius);
+  });
+  it('does neither match nor crash if filters are invalid', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(filter_invalidfilter);
+    olStyle = olStyle as OlParserStyleFct;
+    expect(olStyle).toBeDefined();
+
+    const noMatchFilterFeat = new OlFeature();
+    noMatchFilterFeat.set('state', 'germany');
+    noMatchFilterFeat.set('population', 100000);
+    noMatchFilterFeat.set('name', 'Schalke');
+    const noMatchStyle = olStyle(noMatchFilterFeat, 1);
+    expect(noMatchStyle).toBeDefined();
+    const noMatchRadius = noMatchStyle[0].getImage().getRadius();
+    const expecNoMatchSymbolizer: MarkSymbolizer = filter_invalidfilter.rules[1].symbolizers[0] as MarkSymbolizer;
+    expect(noMatchRadius).toBeCloseTo(expecNoMatchSymbolizer.radius);
+  });
+
+  describe('#getOlStyleTypeFromGeoStylerStyle', () => {
+    it('is defined', () => {
+      expect(styleParser.getOlStyleTypeFromGeoStylerStyle).toBeDefined();
+    });
+  });
+
+  describe('#geoStylerStyleToOlStyle', () => {
+    it('is defined', () => {
+      expect(styleParser.geoStylerStyleToOlStyle).toBeDefined();
+    });
+  });
+
+  describe('#geoStylerStyleToOlStyleArray', () => {
+    it('is defined', () => {
+      expect(styleParser.geoStylerStyleToOlStyleArray).toBeDefined();
+    });
+  });
+
+  describe('#geoStylerStyleToOlParserStyleFct', () => {
+    it('is defined', () => {
+      expect(styleParser.geoStylerStyleToOlParserStyleFct).toBeDefined();
+    });
+  });
+
+  describe('#geoStylerFilterToOlParserFilter', () => {
+    it('is defined', () => {
+      expect(styleParser.geoStylerFilterToOlParserFilter).toBeDefined();
+    });
+  });
+
+  describe('#getOlSymbolizerFromSymbolizer', () => {
+    it('is defined', () => {
+      expect(styleParser.getOlSymbolizerFromSymbolizer).toBeDefined();
+    });
+  });
+
+  describe('#getOlPointSymbolizerFromMarkSymbolizer', () => {
+    it('is defined', () => {
+      expect(styleParser.getOlPointSymbolizerFromMarkSymbolizer).toBeDefined();
+    });
+  });
+
+  describe('#getOlIconSymbolizerFromIconSymbolizer', () => {
+    it('is defined', () => {
+      expect(styleParser.getOlIconSymbolizerFromIconSymbolizer).toBeDefined();
+    });
+  });
+
+  describe('#getOlTextSymbolizerFromTextSymbolizer', () => {
+    it('is defined', () => {
+      expect(styleParser.getOlTextSymbolizerFromTextSymbolizer).toBeDefined();
+    });
+  });
+
+  describe('#getOlPolygonSymbolizerFromFillSymbolizer', () => {
+    it('is defined', () => {
+      expect(styleParser.getOlPolygonSymbolizerFromFillSymbolizer).toBeDefined();
+    });
+  });
+
+  describe('#getOlLineSymbolizerFromLineSymbolizer', () => {
+    it('is defined', () => {
+      expect(styleParser.getOlLineSymbolizerFromLineSymbolizer).toBeDefined();
+    });
+  });
+
+  // describe('#getSldComparisonFilterFromComparisonFilte', () => {
+  //   it('is defined', () => {
+  //     expect(styleParser.getSldComparisonFilterFromComparisonFilter).toBeDefined();
+  //   });
+  // });
+
+  // describe('#getSldFilterFromFilter', () => {
+  //   it('is defined', () => {
+  //     expect(styleParser.getSldFilterFromFilter).toBeDefined();
+  //   });
+  // });
 
 });

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -8,13 +8,15 @@ import {
   MarkSymbolizer,
   Operator,
   PointSymbolizer,
+  ReadStyleResult,
   Rule,
   Style,
   StyleParser,
   StyleType,
   Symbolizer,
   TextSymbolizer,
-  UnsupportedProperties
+  UnsupportedProperties,
+  WriteStyleResult
 } from 'geostyler-style';
 
 import OlImageState from 'ol/ImageState';
@@ -48,7 +50,7 @@ export interface OlParserStyleFct {
  * @class OlStyleParser
  * @implements StyleParser
  */
-export class OlStyleParser implements StyleParser {
+export class OlStyleParser implements StyleParser<OlStyleLike> {
 
   /**
    * The name of the OlStyleParser.
@@ -489,18 +491,24 @@ export class OlStyleParser implements StyleParser {
    * @param olStyle The style to be parsed
    * @return The Promise resolving with the GeoStyler-Style Style
    */
-  readStyle(olStyle: OlStyleLike): Promise<Style> {
-    return new Promise<Style>((resolve, reject) => {
+  readStyle(olStyle: OlStyleLike): Promise<ReadStyleResult> {
+    return new Promise<ReadStyleResult>((resolve) => {
       try {
         if (this.isOlParserStyleFct(olStyle)) {
-          resolve(olStyle.__geoStylerStyle);
+          resolve({
+            output: olStyle.__geoStylerStyle
+          });
         } else {
           olStyle = olStyle as OlStyle | OlStyle[];
           const geoStylerStyle: Style = this.olStyleToGeoStylerStyle(olStyle);
-          resolve(geoStylerStyle);
+          resolve({
+            output: geoStylerStyle
+          });
         }
       } catch (error) {
-        reject(error);
+        resolve({
+          errors: [error]
+        });
       }
     });
   }
@@ -519,15 +527,17 @@ export class OlStyleParser implements StyleParser {
    * @param {Style} geoStylerStyle A GeoStyler-Style Style.
    * @return {Promise} The Promise resolving with one of above mentioned style types.
    */
-  writeStyle(geoStylerStyle: Style): Promise<(any)> {
-    return new Promise<any>((resolve, reject) => {
+  writeStyle(geoStylerStyle: Style): Promise<WriteStyleResult<OlStyleLike>> {
+    return new Promise<WriteStyleResult>((resolve) => {
       try {
-
-        const olStyle: any = this.getOlStyleTypeFromGeoStylerStyle(geoStylerStyle);
-        resolve(olStyle);
-
+        const olStyle = this.getOlStyleTypeFromGeoStylerStyle(geoStylerStyle);
+        resolve({
+          output: olStyle
+        });
       } catch (error) {
-        reject(error);
+        resolve({
+          errors: [error]
+        });
       }
     });
   }

--- a/src/Util/OlStyleUtil.spec.ts
+++ b/src/Util/OlStyleUtil.spec.ts
@@ -188,17 +188,17 @@ describe('OlStyleUtil', () => {
     });
 
     it('returns correct font name (1)', () => {
-      const name = OlStyleUtil.getFontNameFromOlFont(`Normal 13px 'Arial Sans', sans-serif`);
+      const name = OlStyleUtil.getFontNameFromOlFont('Normal 13px \'Arial Sans\', sans-serif');
       expect(name).toEqual('Arial Sans');
     });
 
     it('returns correct font name (2)', () => {
-      const name = OlStyleUtil.getFontNameFromOlFont(`10px Arial`);
+      const name = OlStyleUtil.getFontNameFromOlFont('10px Arial');
       expect(name).toEqual('Arial');
     });
 
     it('returns correct font name (3)', () => {
-      const name = OlStyleUtil.getFontNameFromOlFont(`italic 1.2em "Fira Sans", serif`);
+      const name = OlStyleUtil.getFontNameFromOlFont('italic 1.2em "Fira Sans", serif');
       expect(name).toEqual('Fira Sans');
     });
   });
@@ -209,17 +209,17 @@ describe('OlStyleUtil', () => {
     });
 
     it('returns correct size in pixels (1)', () => {
-      const size = OlStyleUtil.getSizeFromOlFont(`Normal 13px 'Arial Sans', sans-serif`);
+      const size = OlStyleUtil.getSizeFromOlFont('Normal 13px \'Arial Sans\', sans-serif');
       expect(size).toEqual(13);
     });
 
     it('returns correct size in pixels (2)', () => {
-      const size = OlStyleUtil.getSizeFromOlFont(`10px Arial`);
+      const size = OlStyleUtil.getSizeFromOlFont('10px Arial');
       expect(size).toEqual(10);
     });
 
     it('returns 0 if no available size in pixels', () => {
-      const size = OlStyleUtil.getSizeFromOlFont(`italic 1.2em "Fira Sans", serif`);
+      const size = OlStyleUtil.getSizeFromOlFont('italic 1.2em "Fira Sans", serif');
       expect(size).toEqual(0);
     });
   });
@@ -284,11 +284,9 @@ describe('OlStyleUtil', () => {
       expect(got).toBe('||');
       const mockFn = jest.fn(() => {return 'FOO'; });
       got = OlStyleUtil.resolveAttributeTemplate(feat, template, '', mockFn);
-      expect(mockFn.mock.calls.length).toBe(2);
-      expect(mockFn.mock.calls[0][0]).toBe('exists-and-is-undefined');
-      expect(mockFn.mock.calls[0][1]).toBe(undefined);
-      expect(mockFn.mock.calls[1][0]).toBe('exists-and-is-null');
-      expect(mockFn.mock.calls[1][1]).toBe(null);
+      expect(mockFn).toHaveBeenCalledTimes(2);
+      expect(mockFn).toHaveBeenCalledWith('exists-and-is-undefined', undefined);
+      expect(mockFn).toHaveBeenCalledWith('exists-and-is-null', null);
       expect(got).toBe('FOO|FOO|');
     });
 

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -215,7 +215,7 @@ class OlStyleUtil {
     template: string,
     noValueFoundText: string = 'n.v.',
     valueAdjust: Function = (key: string, val: any) => val
-    ) {
+  ) {
 
     let attributeTemplatePrefix = '\\{\\{';
     let attributeTemplateSuffix = '\\}\\}';


### PR DESCRIPTION
## Description

This updates the parser to work with geostyler-style 5. As the ouput of `readStyle` and `writeStyle` change accordingly this is a **breaking-change** :exclamation: 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Feature
- [x] Dependency updates

## Do you introduce a breaking change?

- [x] Yes