### PR TITLE
Remove @terrestris/ol-util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3596,24 +3596,6 @@
         "defer-to-connect": "^2.0.0"
       }
     },
-    "@terrestris/base-util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/base-util/-/base-util-1.0.1.tgz",
-      "integrity": "sha512-ML1IaqZXGWlXrI8pEAnGZv6qPmW72uBZkbc5NvZcBDattpXmrE3rCntTou1t/zLaOz0v4qmG5KORMTSzOeScRQ==",
-      "requires": {
-        "@types/lodash": "^4.14.168",
-        "@types/loglevel": "^1.6.3",
-        "@types/url-parse": "^1.4.3",
-        "@types/url-search-params": "^1.1.0",
-        "@types/validator": "^13.1.3",
-        "lodash": "^4.17.20",
-        "loglevel": "^1.7.1",
-        "query-string": "^6.13.8",
-        "url-parse": "^1.4.7",
-        "url-search-params": "^1.1.0",
-        "validator": "^13.5.2"
-      }
-    },
     "@terrestris/eslint-config-typescript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@terrestris/eslint-config-typescript/-/eslint-config-typescript-2.0.0.tgz",
@@ -3624,1354 +3606,11 @@
         "typescript": "*"
       }
     },
-    "@terrestris/ol-util": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
-      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
-      "requires": {
-        "@terrestris/base-util": "^1.0.0",
-        "@turf/turf": "^5.1.6",
-        "lodash": "^4.17.20",
-        "proj4": "^2.7.0",
-        "shpjs": "^3.6.3"
-      }
-    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
-    },
-    "@turf/along": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
-      "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
-      "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/area": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
-      "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/bbox": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/bbox-clip": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
-      "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "lineclip": "^1.1.5"
-      }
-    },
-    "@turf/bbox-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
-      "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
-      "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/bezier-spline": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
-      "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-clockwise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
-      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-contains": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
-      "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-crosses": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
-      "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
-      }
-    },
-    "@turf/boolean-disjoint": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
-      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
-      }
-    },
-    "@turf/boolean-equal": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
-      "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
-      "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "geojson-equality": "0.1.6"
-      }
-    },
-    "@turf/boolean-overlap": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
-      "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-overlap": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "geojson-equality": "0.1.6"
-      }
-    },
-    "@turf/boolean-parallel": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
-      "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
-      "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5"
-      }
-    },
-    "@turf/boolean-point-in-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-point-on-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
-      "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/boolean-within": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
-      "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/buffer": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/projection": "^5.1.5",
-        "d3-geo": "1.7.1",
-        "turf-jsts": "*"
-      }
-    },
-    "@turf/center": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/center-mean": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
-      "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/center-median": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
-      "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
-      "requires": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/center-of-mass": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
-      "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
-      "requires": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/convex": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/centroid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-      "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/circle": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
-      "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
-      "requires": {
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/clean-coords": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
-      "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/clone": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/clusters": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
-      "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/clusters-dbscan": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
-      "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "density-clustering": "1.3.0"
-      }
-    },
-    "@turf/clusters-kmeans": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
-      "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "skmeans": "0.9.7"
-      }
-    },
-    "@turf/collect": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
-      "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "rbush": "^2.0.1"
-      },
-      "dependencies": {
-        "quickselect": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
-        },
-        "rbush": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "requires": {
-            "quickselect": "^1.0.1"
-          }
-        }
-      }
-    },
-    "@turf/combine": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
-      "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/concave": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
-      "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/tin": "^5.1.5",
-        "topojson-client": "3.x",
-        "topojson-server": "3.x"
-      }
-    },
-    "@turf/convex": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
-      "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "concaveman": "*"
-      }
-    },
-    "@turf/destination": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
-      "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/difference": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
-      "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
-      "requires": {
-        "@turf/area": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "@turf/dissolve": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
-      "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
-      "requires": {
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
-        "geojson-rbush": "2.1.0",
-        "get-closest": "*"
-      }
-    },
-    "@turf/distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
-      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/ellipse": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
-      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/transform-rotate": "^5.1.5"
-      }
-    },
-    "@turf/envelope": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
-      "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/explode": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
-      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/flatten": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
-      "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/flip": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
-      "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/great-circle": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
-      "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/helpers": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-    },
-    "@turf/hex-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
-      "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
-      "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/interpolate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
-      "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/hex-grid": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/point-grid": "^5.1.5",
-        "@turf/square-grid": "^5.1.5",
-        "@turf/triangle-grid": "^5.1.5"
-      }
-    },
-    "@turf/intersect": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
-      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
-      "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "@turf/invariant": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
-      "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/isobands": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
-      "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
-      "requires": {
-        "@turf/area": "^5.1.5",
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/isolines": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
-      "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/kinks": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
-      "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/length": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
-      "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
-      "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/line-arc": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
-      "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
-      "requires": {
-        "@turf/circle": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/line-chunk": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
-      "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/length": "^5.1.5",
-        "@turf/line-slice-along": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/line-intersect": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
-      "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "@turf/line-offset": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
-      "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/line-overlap": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
-      "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
-      "requires": {
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "@turf/line-segment": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
-      "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/line-slice": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
-      "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5"
-      }
-    },
-    "@turf/line-slice-along": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
-      "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
-      "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/line-split": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
-      "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
-        "@turf/square": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "@turf/line-to-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
-      "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/mask": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
-      "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
-        "rbush": "^2.0.1"
-      },
-      "dependencies": {
-        "quickselect": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
-        },
-        "rbush": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "requires": {
-            "quickselect": "^1.0.1"
-          }
-        }
-      }
-    },
-    "@turf/meta": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
-      "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/midpoint": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
-      "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
-      "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/nearest-point": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
-      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/nearest-point-on-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
-      "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
-      "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/nearest-point-to-line": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
-      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
-      "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/point-to-line-distance": "^5.1.5",
-        "object-assign": "*"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
-          "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
-        },
-        "@turf/invariant": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
-          "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
-          "requires": {
-            "@turf/helpers": "^6.3.0"
-          }
-        },
-        "@turf/meta": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
-          "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
-          "requires": {
-            "@turf/helpers": "^6.3.0"
-          }
-        }
-      }
-    },
-    "@turf/planepoint": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
-      "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/point-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
-      "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
-      "requires": {
-        "@turf/boolean-within": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/point-on-feature": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
-      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/nearest-point": "^5.1.5"
-      }
-    },
-    "@turf/point-to-line-distance": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
-      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
-      "requires": {
-        "@turf/bearing": "6.x",
-        "@turf/distance": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/projection": "6.x",
-        "@turf/rhumb-bearing": "6.x",
-        "@turf/rhumb-distance": "6.x"
-      },
-      "dependencies": {
-        "@turf/bearing": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.3.0.tgz",
-          "integrity": "sha512-apuUm9xN6VQLO33m7F2mmzlm3dHfeesJjMSzh9iehGtgmp1IaVndjdcIvs0ieiwm8bN9UhwXpfPtO3pV0n9SFw==",
-          "requires": {
-            "@turf/helpers": "^6.3.0",
-            "@turf/invariant": "^6.3.0"
-          }
-        },
-        "@turf/clone": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.3.0.tgz",
-          "integrity": "sha512-GAgN89/9GCqUKECB1oY2hcTs0K2rZj+a2tY6VfM0ef9wwckuQZCKi+kKGUzhKVrmHee15jKV8n6DY0er8OndKg==",
-          "requires": {
-            "@turf/helpers": "^6.3.0"
-          }
-        },
-        "@turf/distance": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.3.0.tgz",
-          "integrity": "sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==",
-          "requires": {
-            "@turf/helpers": "^6.3.0",
-            "@turf/invariant": "^6.3.0"
-          }
-        },
-        "@turf/helpers": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
-          "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
-        },
-        "@turf/invariant": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
-          "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
-          "requires": {
-            "@turf/helpers": "^6.3.0"
-          }
-        },
-        "@turf/meta": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
-          "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
-          "requires": {
-            "@turf/helpers": "^6.3.0"
-          }
-        },
-        "@turf/projection": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.3.0.tgz",
-          "integrity": "sha512-IpSs7Q6G6xi47ynVlYYVegPLy6Jc0yo3/DcIm83jaJa4NnzPFXIFZT0v9Fe1N8MraHZqiqaSPbVnJXCGwR12lg==",
-          "requires": {
-            "@turf/clone": "^6.3.0",
-            "@turf/helpers": "^6.3.0",
-            "@turf/meta": "^6.3.0"
-          }
-        },
-        "@turf/rhumb-bearing": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.3.0.tgz",
-          "integrity": "sha512-/c/BE3huEUrwN6gx7Bg2FzfJqeU+TWk/slQPDHpbVunlIPbS6L28brqSVD+KXfMG8HQIzynz6Pm4Y+j5Iv4aWA==",
-          "requires": {
-            "@turf/helpers": "^6.3.0",
-            "@turf/invariant": "^6.3.0"
-          }
-        },
-        "@turf/rhumb-distance": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.3.0.tgz",
-          "integrity": "sha512-wMIQVvznusonnp/POeucFdA4Rubn0NrkcEMdxdcCgFK7OmTz0zU4CEnNONF2IUGkQ5WwoKiuS7MOTQ8OuCjSfQ==",
-          "requires": {
-            "@turf/helpers": "^6.3.0",
-            "@turf/invariant": "^6.3.0"
-          }
-        }
-      }
-    },
-    "@turf/points-within-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/polygon-tangents": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
-      "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/polygon-to-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
-      "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/polygonize": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
-      "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/envelope": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/projection": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/random": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
-      "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/rewind": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
-      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
-      "requires": {
-        "@turf/boolean-clockwise": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/rhumb-destination": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
-      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/rhumb-distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/sample": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
-      "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/sector": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
-      "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
-      "requires": {
-        "@turf/circle": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-arc": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/shortest-path": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
-      "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/transform-scale": "^5.1.5"
-      }
-    },
-    "@turf/simplify": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
-      "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
-      "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/square": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
-      "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
-      "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/square-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
-      "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
-      "requires": {
-        "@turf/boolean-contains": "^5.1.5",
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/standard-deviational-ellipse": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
-      "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
-      "requires": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/ellipse": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/points-within-polygon": "^5.1.5"
-      }
-    },
-    "@turf/tag": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
-      "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/tesselate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
-      "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "earcut": "^2.0.0"
-      }
-    },
-    "@turf/tin": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
-      "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/transform-rotate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
-      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
-      "requires": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      }
-    },
-    "@turf/transform-scale": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
-      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      }
-    },
-    "@turf/transform-translate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
-      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5"
-      }
-    },
-    "@turf/triangle-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
-      "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
-      "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "@turf/truncate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
-      "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/turf": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
-      "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
-      "requires": {
-        "@turf/along": "5.1.x",
-        "@turf/area": "5.1.x",
-        "@turf/bbox": "5.1.x",
-        "@turf/bbox-clip": "5.1.x",
-        "@turf/bbox-polygon": "5.1.x",
-        "@turf/bearing": "5.1.x",
-        "@turf/bezier-spline": "5.1.x",
-        "@turf/boolean-clockwise": "5.1.x",
-        "@turf/boolean-contains": "5.1.x",
-        "@turf/boolean-crosses": "5.1.x",
-        "@turf/boolean-disjoint": "5.1.x",
-        "@turf/boolean-equal": "5.1.x",
-        "@turf/boolean-overlap": "5.1.x",
-        "@turf/boolean-parallel": "5.1.x",
-        "@turf/boolean-point-in-polygon": "5.1.x",
-        "@turf/boolean-point-on-line": "5.1.x",
-        "@turf/boolean-within": "5.1.x",
-        "@turf/buffer": "5.1.x",
-        "@turf/center": "5.1.x",
-        "@turf/center-mean": "5.1.x",
-        "@turf/center-median": "5.1.x",
-        "@turf/center-of-mass": "5.1.x",
-        "@turf/centroid": "5.1.x",
-        "@turf/circle": "5.1.x",
-        "@turf/clean-coords": "5.1.x",
-        "@turf/clone": "5.1.x",
-        "@turf/clusters": "5.1.x",
-        "@turf/clusters-dbscan": "5.1.x",
-        "@turf/clusters-kmeans": "5.1.x",
-        "@turf/collect": "5.1.x",
-        "@turf/combine": "5.1.x",
-        "@turf/concave": "5.1.x",
-        "@turf/convex": "5.1.x",
-        "@turf/destination": "5.1.x",
-        "@turf/difference": "5.1.x",
-        "@turf/dissolve": "5.1.x",
-        "@turf/distance": "5.1.x",
-        "@turf/ellipse": "5.1.x",
-        "@turf/envelope": "5.1.x",
-        "@turf/explode": "5.1.x",
-        "@turf/flatten": "5.1.x",
-        "@turf/flip": "5.1.x",
-        "@turf/great-circle": "5.1.x",
-        "@turf/helpers": "5.1.x",
-        "@turf/hex-grid": "5.1.x",
-        "@turf/interpolate": "5.1.x",
-        "@turf/intersect": "5.1.x",
-        "@turf/invariant": "5.1.x",
-        "@turf/isobands": "5.1.x",
-        "@turf/isolines": "5.1.x",
-        "@turf/kinks": "5.1.x",
-        "@turf/length": "5.1.x",
-        "@turf/line-arc": "5.1.x",
-        "@turf/line-chunk": "5.1.x",
-        "@turf/line-intersect": "5.1.x",
-        "@turf/line-offset": "5.1.x",
-        "@turf/line-overlap": "5.1.x",
-        "@turf/line-segment": "5.1.x",
-        "@turf/line-slice": "5.1.x",
-        "@turf/line-slice-along": "5.1.x",
-        "@turf/line-split": "5.1.x",
-        "@turf/line-to-polygon": "5.1.x",
-        "@turf/mask": "5.1.x",
-        "@turf/meta": "5.1.x",
-        "@turf/midpoint": "5.1.x",
-        "@turf/nearest-point": "5.1.x",
-        "@turf/nearest-point-on-line": "5.1.x",
-        "@turf/nearest-point-to-line": "5.1.x",
-        "@turf/planepoint": "5.1.x",
-        "@turf/point-grid": "5.1.x",
-        "@turf/point-on-feature": "5.1.x",
-        "@turf/point-to-line-distance": "5.1.x",
-        "@turf/points-within-polygon": "5.1.x",
-        "@turf/polygon-tangents": "5.1.x",
-        "@turf/polygon-to-line": "5.1.x",
-        "@turf/polygonize": "5.1.x",
-        "@turf/projection": "5.1.x",
-        "@turf/random": "5.1.x",
-        "@turf/rewind": "5.1.x",
-        "@turf/rhumb-bearing": "5.1.x",
-        "@turf/rhumb-destination": "5.1.x",
-        "@turf/rhumb-distance": "5.1.x",
-        "@turf/sample": "5.1.x",
-        "@turf/sector": "5.1.x",
-        "@turf/shortest-path": "5.1.x",
-        "@turf/simplify": "5.1.x",
-        "@turf/square": "5.1.x",
-        "@turf/square-grid": "5.1.x",
-        "@turf/standard-deviational-ellipse": "5.1.x",
-        "@turf/tag": "5.1.x",
-        "@turf/tesselate": "5.1.x",
-        "@turf/tin": "5.1.x",
-        "@turf/transform-rotate": "5.1.x",
-        "@turf/transform-scale": "5.1.x",
-        "@turf/transform-translate": "5.1.x",
-        "@turf/triangle-grid": "5.1.x",
-        "@turf/truncate": "5.1.x",
-        "@turf/union": "5.1.x",
-        "@turf/unkink-polygon": "5.1.x",
-        "@turf/voronoi": "5.1.x"
-      }
-    },
-    "@turf/union": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
-      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "@turf/unkink-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
-      "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
-      "requires": {
-        "@turf/area": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "rbush": "^2.0.1"
-      },
-      "dependencies": {
-        "quickselect": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
-        },
-        "rbush": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "requires": {
-            "quickselect": "^1.0.1"
-          }
-        }
-      }
-    },
-    "@turf/voronoi": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
-      "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "d3-voronoi": "1.1.2"
-      }
     },
     "@types/babel__core": {
       "version": "7.1.16",
@@ -5121,14 +3760,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
       "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
     },
-    "@types/loglevel": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@types/loglevel/-/loglevel-1.6.3.tgz",
-      "integrity": "sha512-v2YWQQgqtNXAzybOT9qV3CIJqSeoaMUwmBfIMTQdvhsWUybYic/zNGccKH494naWKJ7zUm+VTgFepJfTrbCCJQ==",
-      "requires": {
-        "loglevel": "*"
-      }
-    },
     "@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
@@ -5173,21 +3804,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
-    },
-    "@types/url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw=="
-    },
-    "@types/url-search-params": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/url-search-params/-/url-search-params-1.1.0.tgz",
-      "integrity": "sha512-MAiEDfjOmuZLSx2rrRj3rR2729wygQbq5mdQsEW4gMRFRDoW93lUU3n0ablmbAIL9pzharzhmcEjrO2zW0JSKg=="
-    },
-    "@types/validator": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
-      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA=="
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -6417,6 +5033,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -6676,7 +5293,8 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -6689,17 +5307,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "concaveman": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.0.tgz",
-      "integrity": "sha512-OcqechF2/kubbffomKqjGEkb0ndlYhEbmyg/fxIGqdfYp5AZjD2Kl5hc97Hh3ngEuHU2314Z4KDbxL7qXGWrQQ==",
-      "requires": {
-        "point-in-polygon": "^1.0.1",
-        "rbush": "^3.0.0",
-        "robust-predicates": "^2.0.4",
-        "tinyqueue": "^2.0.3"
-      }
     },
     "configstore": {
       "version": "5.0.1",
@@ -6874,24 +5481,6 @@
         }
       }
     },
-    "d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
-    "d3-geo": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
-      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
-      "requires": {
-        "d3-array": "1"
-      }
-    },
-    "d3-voronoi": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -6957,11 +5546,6 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
     "decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -6976,19 +5560,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -7018,6 +5589,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -7049,11 +5621,6 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
-    },
-    "density-clustering": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
-      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -7122,11 +5689,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
-    },
-    "earcut": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -7825,11 +6387,6 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
-    },
     "find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -7909,7 +6466,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -7938,24 +6496,6 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
-    },
-    "geojson-equality": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
-      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
-      "requires": {
-        "deep-equal": "^1.0.0"
-      }
-    },
-    "geojson-rbush": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
-      "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
-      "requires": {
-        "@turf/helpers": "*",
-        "@turf/meta": "*",
-        "rbush": "*"
-      }
     },
     "geostyler-style": {
       "version": "5.0.1",
@@ -8004,15 +6544,11 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
-    "get-closest": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
-      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
-    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -8196,6 +6732,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -8226,7 +6763,8 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -8309,6 +6847,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -8333,11 +6872,6 @@
       "requires": {
         "minimatch": "^3.0.4"
       }
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -8656,14 +7190,6 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
     },
-    "is-arguments": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
-      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
-      "requires": {
-        "call-bind": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -8687,11 +7213,6 @@
       "requires": {
         "has": "^1.0.3"
       }
-    },
-    "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-docker": {
       "version": "2.1.1",
@@ -8818,15 +7339,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true
-    },
-    "is-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.1"
-      }
     },
     "is-scoped": {
       "version": "2.1.0",
@@ -11880,14 +10392,6 @@
         "verror": "1.10.0"
       }
     },
-    "jszip": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
-      "requires": {
-        "pako": "~1.0.2"
-      }
-    },
     "keyv": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
@@ -11945,19 +10449,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
-    },
-    "lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "requires": {
-        "immediate": "~3.0.5"
-      }
-    },
-    "lineclip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
-      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
     },
     "lines-and-columns": {
       "version": "1.1.6",
@@ -12372,21 +10863,11 @@
         }
       }
     },
-    "loglevel": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
-      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
-    },
     "lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true
-    },
-    "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -12536,11 +11017,6 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
-    },
-    "mgrs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
-      "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk="
     },
     "micromatch": {
       "version": "4.0.2",
@@ -13080,21 +11556,14 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.2",
@@ -13463,11 +11932,6 @@
         }
       }
     },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13500,15 +11964,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
-    },
-    "parsedbf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/parsedbf/-/parsedbf-1.1.1.tgz",
-      "integrity": "sha512-jndFmhcrzSAGCMccM4za+3bIRxqV6L2doQjYN8Xgz0kZUpyBT5I8Gs6Y6hL5GcO2rih9OBkPcLlx2uBoLi8R8Q==",
-      "requires": {
-        "iconv-lite": "^0.4.15",
-        "text-encoding-polyfill": "^0.6.7"
-      }
     },
     "path-exists": {
       "version": "4.0.0",
@@ -13580,11 +12035,6 @@
         "find-up": "^4.0.0"
       }
     },
-    "point-in-polygon": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
-      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -13628,15 +12078,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
-    },
-    "proj4": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.2.tgz",
-      "integrity": "sha512-x/EboBmIq48a9FED0Z9zWCXkd8VIpXHLsyEXljGtsnzeztC41bFjPjJ0S//wBbNLDnDYRe0e6c3FSSiqMCebDA==",
-      "requires": {
-        "mgrs": "1.0.0",
-        "wkt-parser": "^1.2.4"
-      }
     },
     "prompts": {
       "version": "2.4.1",
@@ -13699,22 +12140,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "queue-microtask": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
@@ -13730,7 +12155,8 @@
     "quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -13745,6 +12171,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dev": true,
       "requires": {
         "quickselect": "^2.0.0"
       }
@@ -13870,15 +12297,6 @@
         "@babel/runtime": "^7.8.4"
       }
     },
-    "regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -13980,11 +12398,6 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -14053,11 +12466,6 @@
         "glob": "^7.1.3"
       }
     },
-    "robust-predicates": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
-      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg=="
-    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -14097,7 +12505,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "saxes": {
       "version": "5.0.1",
@@ -14187,18 +12596,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "shpjs": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
-      "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
-      "requires": {
-        "jszip": "^2.4.0",
-        "lie": "^3.0.1",
-        "lru-cache": "^2.7.0",
-        "parsedbf": "^1.1.0",
-        "proj4": "^2.1.4"
-      }
-    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -14227,11 +12624,6 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
-    },
-    "skmeans": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
-      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
     },
     "slash": {
       "version": "3.0.0",
@@ -14332,11 +12724,6 @@
         "through": "2"
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -14376,11 +12763,6 @@
           "dev": true
         }
       }
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "4.0.2",
@@ -14742,11 +13124,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "text-encoding-polyfill": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
-      "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg=="
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -14814,11 +13191,6 @@
         "esm": "^3.2.25"
       }
     },
-    "tinyqueue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14853,22 +13225,6 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
-      }
-    },
-    "topojson-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
-      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
-      "requires": {
-        "commander": "2"
-      }
-    },
-    "topojson-server": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
-      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
-      "requires": {
-        "commander": "2"
       }
     },
     "tough-cookie": {
@@ -14919,11 +13275,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "turf-jsts": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
-      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -15144,15 +13495,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "url-parse": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
-      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -15161,11 +13503,6 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
-    },
-    "url-search-params": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-1.1.0.tgz",
-      "integrity": "sha512-XiO5GLAxmlZgdLob/RmKZRc2INHrssMbpwD6O46JkB1aEJO4fkV3x3mR6+CDX01ijfEUwvfwCiUQZrKqfm1ILw=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -15228,11 +13565,6 @@
       "requires": {
         "builtins": "^1.0.3"
       }
-    },
-    "validator": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
     },
     "verror": {
       "version": "1.10.0",
@@ -15552,11 +13884,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
-    },
-    "wkt-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.4.tgz",
-      "integrity": "sha512-ZzKnc7ml/91fOPh5bANBL4vUlWPIYYv11waCtWTkl2TRN+LEmBg60Q1MA8gqV4hEp4MGfSj9JiHz91zw/gTDXg=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-openlayers-parser",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "lint:typecheck:test": "npm run lint && npm run typecheck && npm run test"
   },
   "dependencies": {
-    "@terrestris/ol-util": "^4.0.1",
     "geostyler-style": "^5.0.1",
     "lodash": "^4.17.15"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-openlayers-parser",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "GeoStyler Style Parser implementation for OpenLayers styles",
   "main": "build/dist/OlStyleParser.js",
   "types": "build/dist/OlStyleParser.d.ts",

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -65,6 +65,7 @@ import ol_polygon_transparentpolygon from '../data/olStyles/polygon_transparentp
 import ol_multi_simplefillSimpleline from '../data/olStyles/multi_simplefillSimpleline';
 import ol_point_styledLabel_static from '../data/olStyles/point_styledLabel_static';
 import ol_point_fontglyph from '../data/olStyles/point_fontglyph';
+import { METERS_PER_UNIT } from 'ol/proj/Units';
 import {
   LineSymbolizer,
   FillSymbolizer,
@@ -74,7 +75,15 @@ import {
 } from 'geostyler-style';
 
 import OlStyleUtil from './Util/OlStyleUtil';
-import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+
+// reverse calculation of resolution for scale (from ol-util MapUtil)
+function getResolutionForScale (scale, units) {
+  let dpi = 25.4 / 0.28;
+  let mpu = METERS_PER_UNIT[units];
+  let inchesPerMeter = 39.37;
+
+  return parseFloat(scale) / (mpu * inchesPerMeter * dpi);
+}
 
 it('OlStyleParser is defined', () => {
   expect(OlStyleParser).toBeDefined();
@@ -902,8 +911,8 @@ describe('OlStyleParser implements StyleParser', () => {
     const withinScale: number = scaleDenomLine.rules[0].scaleDenominator.min;
     const beyondScale: number = scaleDenomLine.rules[0].scaleDenominator.max;
 
-    const resolutionRuleOne = MapUtil.getResolutionForScale(withinScale, 'm');
-    const resolutionRuleTwo = MapUtil.getResolutionForScale(beyondScale, 'm');
+    const resolutionRuleOne = getResolutionForScale(withinScale, 'm');
+    const resolutionRuleTwo = getResolutionForScale(beyondScale, 'm');
 
     const dummyFeat = new OlFeature();
     const styleWithinScale = olStyle(dummyFeat, resolutionRuleOne);
@@ -921,9 +930,9 @@ describe('OlStyleParser implements StyleParser', () => {
     const scaleWithinSecond: number = scaleDenomLineCircle.rules[1].scaleDenominator.min;
     const scaleBeyond: number = scaleDenomLineCircle.rules[1].scaleDenominator.max;
 
-    const resolutionWithinFirst = MapUtil.getResolutionForScale(scaleWithinFirst, 'm');
-    const resolutionWithinSecond = MapUtil.getResolutionForScale(scaleWithinSecond, 'm');
-    const resolutionBeyond = MapUtil.getResolutionForScale(scaleBeyond, 'm');
+    const resolutionWithinFirst = getResolutionForScale(scaleWithinFirst, 'm');
+    const resolutionWithinSecond = getResolutionForScale(scaleWithinSecond, 'm');
+    const resolutionBeyond = getResolutionForScale(scaleBeyond, 'm');
 
     const dummyFeat = new OlFeature();
     const styleWithinFirst = olStyle(dummyFeat, resolutionWithinFirst);
@@ -958,9 +967,9 @@ describe('OlStyleParser implements StyleParser', () => {
     const scaleOverlap: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.min;
     const scaleOnlySecond: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.max - 1;
 
-    const resolutionOnlyFirst = MapUtil.getResolutionForScale(scaleOnlyFirst, 'm');
-    const resolutionOverlap = MapUtil.getResolutionForScale(scaleOverlap, 'm');
-    const resolutionOnlySecond = MapUtil.getResolutionForScale(scaleOnlySecond, 'm');
+    const resolutionOnlyFirst = getResolutionForScale(scaleOnlyFirst, 'm');
+    const resolutionOverlap = getResolutionForScale(scaleOverlap, 'm');
+    const resolutionOnlySecond = getResolutionForScale(scaleOnlySecond, 'm');
 
     const dummyFeat = new OlFeature();
     const styleOnlyFirst = olStyle(dummyFeat, resolutionOnlyFirst);

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -21,7 +21,6 @@ import {
 
 import OlImageState from 'ol/ImageState';
 
-import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import OlGeomPoint from 'ol/geom/Point';
 
 import OlStyle, { StyleFunction as OlStyleFunction, StyleLike as OlStyleLike} from 'ol/style/Style';
@@ -32,6 +31,7 @@ import OlStyleCircle from 'ol/style/Circle';
 import OlStyleFill from 'ol/style/Fill';
 import OlStyleIcon from 'ol/style/Icon';
 import OlStyleRegularshape, { Options as OlStyleRegularshapeOptions } from 'ol/style/RegularShape';
+import { METERS_PER_UNIT } from 'ol/proj/Units';
 
 import OlStyleUtil from './Util/OlStyleUtil';
 import { toContext } from 'ol/render';
@@ -622,7 +622,13 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
     const rules = geoStylerStyle.rules;
     const olStyle = (feature: any, resolution: number): any[] => {
       const styles: any[] = [];
-      const scale = MapUtil.getScaleForResolution(resolution, 'm');
+
+      // calculate scale for resolution (from ol-util MapUtil)
+      const dpi = 25.4 / 0.28;
+      const mpu = METERS_PER_UNIT.m;
+      const inchesPerMeter = 39.37;
+      const scale = resolution * mpu * inchesPerMeter * dpi;
+
       rules.forEach((rule: Rule) => {
         // handling scale denominator
         const minScale = _get(rule, 'scaleDenominator.min');


### PR DESCRIPTION
This removes the `@terrestris/ol-util` as it was only used to calculate the scale for resolution but increased the bundle (and node_modules) size. The corresponding code to calculate the code was just copied in place.