### PR TITLE
Adds unsupportedProperties feedback to WriteStyleResult

### DIFF
--- a/data/olStyles/polygon_simple.ts
+++ b/data/olStyles/polygon_simple.ts
@@ -1,0 +1,10 @@
+import OlStyle from 'ol/style/Style';
+import OlStyleFill from 'ol/style/Fill';
+
+const olPolygonSimple = new OlStyle({
+  fill: new OlStyleFill({
+    color: '#F1337F'
+  })
+});
+
+export default olPolygonSimple;

--- a/data/olStyles/unsupported_properties.ts
+++ b/data/olStyles/unsupported_properties.ts
@@ -1,0 +1,10 @@
+import OlStyle from 'ol/style/Style';
+import OlStyleFill from 'ol/style/Fill';
+
+const olUnsupportedProperties = new OlStyle({
+  fill: new OlStyleFill({
+    color: '#F1337F'
+  })
+});
+
+export default olUnsupportedProperties;

--- a/data/styles/point_simplepoint_filter.ts
+++ b/data/styles/point_simplepoint_filter.ts
@@ -4,7 +4,7 @@ const pointSimplePoint: Style = {
   name: 'OL Style',
   rules: [
     {
-      name: 'OL Style Rule',
+      name: 'OL Style Rule 0',
       filter: ['&&',
         ['==', 'NAME', 'New York'],
         ['!',

--- a/data/styles/point_styledlabel.ts
+++ b/data/styles/point_styledlabel.ts
@@ -4,7 +4,7 @@ const pointStyledLabel: Style = {
   name: 'OL Style',
   rules: [
     {
-      name: 'OL Style Rule',
+      name: 'OL Style Rule 0',
       symbolizers: [{
         kind: 'Text',
         color: '#000000',

--- a/data/styles/polygon_simple.ts
+++ b/data/styles/polygon_simple.ts
@@ -1,0 +1,16 @@
+import { Style } from 'geostyler-style';
+
+const polygonSimple: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Fill',
+        color: '#F1337F'
+      }]
+    }
+  ]
+};
+
+export default polygonSimple;

--- a/data/styles/unsupported_properties.ts
+++ b/data/styles/unsupported_properties.ts
@@ -1,0 +1,17 @@
+import { Style } from 'geostyler-style';
+
+const unsupportedProperties: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Fill',
+        color: '#F1337F',
+        fillOpacity: 0.5
+      }]
+    }
+  ]
+};
+
+export default unsupportedProperties;

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -42,6 +42,7 @@ import scaleDenomLineCircle from '../data/styles/scaleDenom_line_circle';
 import scaleDenomLineCircleOverlap from '../data/styles/scaleDenom_line_circle_overlap';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import polygon_graphicfill_mark from '../data/styles/polygon_graphicFill_mark';
+import polygon_simple from '../data/styles/polygon_simple';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import point_fontglyph from '../data/styles/point_fontglyph';
 import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
@@ -62,6 +63,7 @@ import ol_point_simpleplus from '../data/olStyles/point_simpleplus';
 import ol_point_simpletimes from '../data/olStyles/point_simpletimes';
 import ol_line_simpleline from '../data/olStyles/line_simpleline';
 import ol_polygon_transparentpolygon from '../data/olStyles/polygon_transparentpolygon';
+import ol_polygon_simple from '../data/olStyles/polygon_simple';
 import ol_multi_simplefillSimpleline from '../data/olStyles/multi_simplefillSimpleline';
 import ol_point_styledLabel_static from '../data/olStyles/point_styledLabel_static';
 import ol_point_fontglyph from '../data/olStyles/point_fontglyph';
@@ -1050,6 +1052,12 @@ describe('OlStyleParser implements StyleParser', () => {
     const noMatchRadius = noMatchStyle[0].getImage().getRadius();
     const expecNoMatchSymbolizer: MarkSymbolizer = filter_invalidfilter.rules[1].symbolizers[0] as MarkSymbolizer;
     expect(noMatchRadius).toBeCloseTo(expecNoMatchSymbolizer.radius);
+  });
+
+  it('can write a simple polygon with just fill', async () => {
+    const { output: geoStylerStyle } = await styleParser.writeStyle(polygon_simple);
+    expect(geoStylerStyle).toBeDefined();
+    expect(geoStylerStyle).toEqual(ol_polygon_simple);
   });
 
   describe('#getOlStyleTypeFromGeoStylerStyle', () => {

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -45,6 +45,8 @@ import polygon_graphicfill_mark from '../data/styles/polygon_graphicFill_mark';
 import polygon_simple from '../data/styles/polygon_simple';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import point_fontglyph from '../data/styles/point_fontglyph';
+import unsupported_properties from '../data/styles/unsupported_properties';
+
 import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
 import ol_point_icon from '../data/olStyles/point_icon';
 import ol_point_simplesquare from '../data/olStyles/point_simplesquare';
@@ -67,6 +69,8 @@ import ol_polygon_simple from '../data/olStyles/polygon_simple';
 import ol_multi_simplefillSimpleline from '../data/olStyles/multi_simplefillSimpleline';
 import ol_point_styledLabel_static from '../data/olStyles/point_styledLabel_static';
 import ol_point_fontglyph from '../data/olStyles/point_fontglyph';
+import ol_unsupported_properties from '../data/olStyles/unsupported_properties';
+
 import { METERS_PER_UNIT } from 'ol/proj/Units';
 import {
   LineSymbolizer,
@@ -243,6 +247,12 @@ describe('OlStyleParser implements StyleParser', () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_fontglyph);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_fontglyph);
+    });
+
+    it('can read a simple polygon with just fill', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_polygon_simple);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(polygon_simple);
     });
 
     describe('#olStyleToGeoStylerStyle', () => {
@@ -1058,6 +1068,29 @@ describe('OlStyleParser implements StyleParser', () => {
     const { output: geoStylerStyle } = await styleParser.writeStyle(polygon_simple);
     expect(geoStylerStyle).toBeDefined();
     expect(geoStylerStyle).toEqual(ol_polygon_simple);
+  });
+
+  it('adds unsupportedProperties to the write output', async () => {
+    let {
+      output: olStyle,
+      unsupportedProperties,
+      warnings
+    } = await styleParser.writeStyle(unsupported_properties);
+    expect(olStyle).toBeDefined();
+    const unsupportedGot = {
+      Symbolizer: {
+        FillSymbolizer: {
+          fillOpacity: {
+            info: 'Use opacity instead.',
+            support: 'none'
+          }
+        }
+      }
+    };
+    const warningsGot = ['Your style contains unsupportedProperties!'];
+    expect(unsupportedProperties).toEqual(unsupportedGot);
+    expect(warnings).toEqual(warningsGot);
+    expect(olStyle).toEqual(ol_unsupported_properties);
   });
 
   describe('#getOlStyleTypeFromGeoStylerStyle', () => {


### PR DESCRIPTION
## Description

This adds the `unsupportedProperties` to the `WriteStyleResult`.

It also fixes `getFillSymbolizerFromOlStyle` as it added unneed keys to the output.

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
