### PR TITLE
Update ReadMe code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const pointSimplePoint = {
       symbolizers: [
         {
           kind: "Mark",
-          wellKnownName: "Circle",
+          wellKnownName: "circle",
           color: "#FF0000",
           radius: 6
         }
@@ -35,7 +35,7 @@ const layer = new OlLayerVector();
 
 parser
   .writeStyle(pointSimplePoint)
-  .then(olStyle => layer.setStyle(olStyle))
+  .then(olStyle => layer.setStyle(olStyle.output))
   .catch(error => console.log(error));
 ```
 
@@ -47,7 +47,7 @@ var pointSimplePoint = {
     name: "OL Style Rule 0",
     symbolizers: [{
       kind: "Mark",
-      wellKnownName: "Circle",
+      wellKnownName: "circle",
       color: "#FF0000",
       radius: 6
     }]
@@ -57,6 +57,6 @@ var vectorLayer = new ol.layer.Vector();
 var parser = new GeoStylerOpenlayersParser.OlStyleParser(ol);
 parser.writeStyle(pointSimplePoint)
 .then(function(style) {
- vectorLayer.setStyle(style);
+ vectorLayer.setStyle(style.output);
 });
 ```


### PR DESCRIPTION
## Description

Updates the code examples in the README to work with latest version of the library.

As per release notes at https://github.com/geostyler/geostyler-sld-parser/releases/tag/v3.0.0 the read and write functions return an object with an `output` property.

Also updated the WKN from `Circle` to `circle` as I got the following error from the example: `Error: MarkSymbolizer cannot be parsed. Unsupported WellKnownName.`

It would be nice to add in catching errors in the "plain" JS example, however the `catch` below never seems to be called (I was unable to test the TypeScript error catching):

```
var parser = new GeoStylerOpenlayersParser.OlStyleParser(ol);
parser.writeStyle(pointSimplePoint)
.then(function(style) {
 vectorLayer.setStyle(style.output);
})
.catch(error){
  console.log(error);
}
```

## Related issues or pull requests

https://github.com/compassinformatics/cpsi-mapview/pull/557

## Pull request type

- [X] Documentation content changes

## Do you introduce a breaking change?

- [ ] Yes
- [X] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [X] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [X] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [X] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
