### PR TITLE
Fixes size parsing for IconSyomblizer

### DIFF
--- a/data/olStyles/point_icon.ts
+++ b/data/olStyles/point_icon.ts
@@ -4,7 +4,7 @@ import OlStyleIcon from 'ol/style/Icon';
 const olIconPoint = new OlStyle({
   image: new OlStyleIcon({
     src: 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',
-    scale: 0.1,
+    size: [2, 2],
     rotation: Math.PI / 4,
     opacity: 0.5,
     displacement: [10, 20]

--- a/data/styles/point_icon.ts
+++ b/data/styles/point_icon.ts
@@ -8,7 +8,7 @@ const pointSimplePoint: Style = {
       symbolizers: [{
         kind: 'Icon',
         image: 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',
-        size: 0.1,
+        size: 2,
         opacity: 0.5,
         rotate: 45,
         offset: [10, 20]

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -421,7 +421,7 @@ describe('OlStyleParser implements StyleParser', () => {
       expect(olCircle.getRadius()).toBeCloseTo(expecSymb.radius);
       expect(olCircle.getFill().getColor()).toEqual(expecSymb.color);
     });
-    it('can write a OpenLayers IconSymbolizer', async () => {
+    it('can write an OpenLayers IconSymbolizer', async () => {
       let { output: olStyle } = await styleParser.writeStyle(point_icon);
       olStyle = olStyle as OlStyle;
       expect(olStyle).toBeDefined();
@@ -430,7 +430,8 @@ describe('OlStyleParser implements StyleParser', () => {
       const olIcon: OlStyleIcon = olStyle.getImage() as OlStyleIcon;
 
       expect(olIcon.getSrc()).toEqual(expecSymb.image);
-      expect(olIcon.getScale()).toBeCloseTo(expecSymb.size);
+      expect(olIcon.getSize()[0]).toBeCloseTo(expecSymb.size);
+      expect(olIcon.getSize()[1]).toBeCloseTo(expecSymb.size);
       // Rotation in openlayers is radians while we use degree
       expect(olIcon.getRotation()).toBeCloseTo(expecSymb.rotate! * Math.PI / 180);
       expect(olIcon.getOpacity()).toBeCloseTo(expecSymb.opacity);


### PR DESCRIPTION
## Description

This fixes parsing of the `size` property of the `IconSymbolizer`.

## Related issues or pull requests

https://github.com/geostyler/geostyler/issues/1746

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes (API was broken before)
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
