### PR TITLE
Drop support for IconSymbolizer.size

### DIFF
--- a/data/styles/point_icon.ts
+++ b/data/styles/point_icon.ts
@@ -8,7 +8,6 @@ const pointSimplePoint: Style = {
       symbolizers: [{
         kind: 'Icon',
         image: 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',
-        size: 0.1,
         opacity: 0.5,
         rotate: 45,
         offset: [10, 20]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14948,21 +14948,21 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz",
-      "integrity": "sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==",
+      "version": "7.18.13",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
+      "integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.0",
-        "@babel/helper-module-transforms": "^7.20.2",
-        "@babel/helpers": "^7.20.5",
-        "@babel/parser": "^7.20.5",
+        "@babel/generator": "^7.18.13",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.13",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.5",
-        "@babel/types": "^7.20.5",
+        "@babel/traverse": "^7.18.13",
+        "@babel/types": "^7.18.13",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -14970,128 +14970,6 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "@babel/compat-data": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.5.tgz",
-          "integrity": "sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==",
-          "dev": true
-        },
-        "@babel/generator": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
-          "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.20.5",
-            "@jridgewell/gen-mapping": "^0.3.2",
-            "jsesc": "^2.5.1"
-          }
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.20.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
-          "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.20.0",
-            "@babel/helper-validator-option": "^7.18.6",
-            "browserslist": "^4.21.3",
-            "semver": "^6.3.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.19.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-          "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.18.10",
-            "@babel/types": "^7.19.0"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.20.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-          "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-environment-visitor": "^7.18.9",
-            "@babel/helper-module-imports": "^7.18.6",
-            "@babel/helper-simple-access": "^7.20.2",
-            "@babel/helper-split-export-declaration": "^7.18.6",
-            "@babel/helper-validator-identifier": "^7.19.1",
-            "@babel/template": "^7.18.10",
-            "@babel/traverse": "^7.20.1",
-            "@babel/types": "^7.20.2"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.20.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-          "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.20.2"
-          }
-        },
-        "@babel/helper-string-parser": {
-          "version": "7.19.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-          "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
-          "dev": true
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.19.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-          "dev": true
-        },
-        "@babel/parser": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-          "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
-          "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.18.6",
-            "@babel/generator": "^7.20.5",
-            "@babel/helper-environment-visitor": "^7.18.9",
-            "@babel/helper-function-name": "^7.19.0",
-            "@babel/helper-hoist-variables": "^7.18.6",
-            "@babel/helper-split-export-declaration": "^7.18.6",
-            "@babel/parser": "^7.20.5",
-            "@babel/types": "^7.20.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
-          "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.19.4",
-            "@babel/helper-validator-identifier": "^7.19.1",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "@jridgewell/gen-mapping": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/set-array": "^1.0.1",
-            "@jridgewell/sourcemap-codec": "^1.4.10",
-            "@jridgewell/trace-mapping": "^0.3.9"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -15445,95 +15323,14 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.6.tgz",
-      "integrity": "sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.5",
-        "@babel/types": "^7.20.5"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
-          "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.20.5",
-            "@jridgewell/gen-mapping": "^0.3.2",
-            "jsesc": "^2.5.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.19.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-          "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.18.10",
-            "@babel/types": "^7.19.0"
-          }
-        },
-        "@babel/helper-string-parser": {
-          "version": "7.19.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-          "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
-          "dev": true
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.19.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-          "dev": true
-        },
-        "@babel/parser": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-          "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
-          "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.18.6",
-            "@babel/generator": "^7.20.5",
-            "@babel/helper-environment-visitor": "^7.18.9",
-            "@babel/helper-function-name": "^7.19.0",
-            "@babel/helper-hoist-variables": "^7.18.6",
-            "@babel/helper-split-export-declaration": "^7.18.6",
-            "@babel/parser": "^7.20.5",
-            "@babel/types": "^7.20.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.20.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
-          "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.19.4",
-            "@babel/helper-validator-identifier": "^7.19.1",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "@jridgewell/gen-mapping": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/set-array": "^1.0.1",
-            "@jridgewell/sourcemap-codec": "^1.4.10",
-            "@jridgewell/trace-mapping": "^0.3.9"
-          }
-        }
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/highlight": {
@@ -16621,9 +16418,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
+      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -16644,9 +16441,9 @@
           "dev": true
         },
         "globals": {
-          "version": "13.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+          "version": "13.17.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -16676,15 +16473,21 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.5"
+        "minimatch": "^3.0.4"
       }
+    },
+    "@humanwhocodes/gitignore-to-minimatch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+      "dev": true
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
@@ -19729,15 +19532,15 @@
       }
     },
     "eslint": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-      "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
+      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.11.6",
+        "@eslint/eslintrc": "^1.3.1",
+        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -19753,15 +19556,15 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
+        "globby": "^11.1.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -19851,9 +19654,9 @@
           }
         },
         "globals": {
-          "version": "13.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+          "version": "13.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -19967,9 +19770,9 @@
       "dev": true
     },
     "espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
@@ -19993,9 +19796,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
           "dev": true
         }
       }
@@ -20222,9 +20025,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
     "forever-agent": {
@@ -22850,12 +22653,6 @@
         }
       }
     },
-    "js-sdsl": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
-      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -22971,7 +22768,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-pretty-compact": {
@@ -23243,9 +23040,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
@@ -24538,9 +24335,9 @@
       }
     },
     "qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "querystringify": {
@@ -25356,7 +25153,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -86,7 +86,10 @@ import {
 
 import OlStyleUtil from './Util/OlStyleUtil';
 import function_boolean from '../data/styles/function_boolean';
-import { olBoolean1 as ol_function_boolean_fillsymbolizer1, olBoolean2 as ol_function_boolean_fillsymbolizer2 } from '../data/olStyles/function_boolean';
+import {
+  olBoolean1 as ol_function_boolean_fillsymbolizer1,
+  olBoolean2 as ol_function_boolean_fillsymbolizer2
+} from '../data/olStyles/function_boolean';
 
 // reverse calculation of resolution for scale (from ol-util MapUtil)
 function getResolutionForScale (scale, units) {
@@ -132,100 +135,100 @@ describe('OlStyleParser implements StyleParser', () => {
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplepoint);
     });
-    it('can read a OpenLayers PointSymbolizer', async () => {
+    it('can read an OpenLayers PointSymbolizer', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplepoint);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplepoint);
     });
-    it('can read a OpenLayers IconSymbolizer', async () => {
+    it('can read an OpenLayers IconSymbolizer', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_icon);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_icon);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName Square', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName Square', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplesquare);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplesquare);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName Star', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName Star', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplestar);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplestar);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName Triangle', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName Triangle', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpletriangle);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simpletriangle);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName Cross', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName Cross', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplecross);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplecross);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName X', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName X', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplex);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplex);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://slash', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName shape://slash', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpleslash);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simpleslash);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://backslash', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName shape://backslash', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplebackslash);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplebackslash);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://vertline', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName shape://vertline', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplevertline);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplevertline);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://horline', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName shape://horline', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplehorline);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplehorline);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://carrow', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName shape://carrow', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplecarrow);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplecarrow);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://oarrow', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName shape://oarrow', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpleoarrow);
       expect(geoStylerStyle).toBeDefined();
       // using point_simplecarrow here since reading OlStyle cannot distinguish
       // between carrow and oarrow
       expect(geoStylerStyle).toEqual(point_simplecarrow);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://dot', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName shape://dot', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpledot);
       expect(geoStylerStyle).toBeDefined();
       // using point_simplepoint here since reading OlStyle cannot distinguish
       // between circle and dot
       expect(geoStylerStyle).toEqual(point_simplepoint);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://plus', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName shape://plus', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpleplus);
       expect(geoStylerStyle).toBeDefined();
       // using point_simplecross here since reading OlStyle cannot distinguish
       // between cross and plus
       expect(geoStylerStyle).toEqual(point_simplecross);
     });
-    it('can read a OpenLayers MarkSymbolizer as WellKnownName shape://times', async () => {
+    it('can read an OpenLayers MarkSymbolizer as WellKnownName shape://times', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpletimes);
       expect(geoStylerStyle).toBeDefined();
       // using point_simplex here since reading OlStyle cannot distinguish
       // between x and times
       expect(geoStylerStyle).toEqual(point_simplex);
     });
-    it('can read a OpenLayers LineSymbolizer', async () => {
+    it('can read an OpenLayers LineSymbolizer', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_line_simpleline);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(line_simpleline);
     });
-    it('can read a OpenLayers PolygonSymbolizer', async () => {
+    it('can read an OpenLayers PolygonSymbolizer', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_polygon_transparentpolygon);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(polygon_transparentpolygon);
@@ -235,12 +238,12 @@ describe('OlStyleParser implements StyleParser', () => {
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(multi_simplefillSimpleline);
     });
-    it('can read a OpenLayers TextSymbolizer with static text', async () => {
+    it('can read an OpenLayers TextSymbolizer with static text', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_styledLabel_static);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_styledLabel_static);
     });
-    // it('can read a OpenLayers style with a filter', () => {
+    // it('can read an OpenLayers style with a filter', () => {
     //   expect.assertions(2);
     //   const sld = fs.readFileSync( './data/slds/point_simplepoint_filter.sld', 'utf8');
     //   const { output: geoStylerStyle } = await styleParser.readStyle(sld)
@@ -249,7 +252,7 @@ describe('OlStyleParser implements StyleParser', () => {
     //       expect(geoStylerStyle).toEqual(point_simplepoint_filter);
     //     });
     // });
-    it('can read a OpenLayers MarkSymbolizer based on a font glyph (WellKnownName starts with ttf://)', async () => {
+    it('can read an OpenLayers MarkSymbolizer based on a font glyph (WellKnownName starts with ttf://)', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_fontglyph);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_fontglyph);
@@ -415,7 +418,7 @@ describe('OlStyleParser implements StyleParser', () => {
       expect(olStyles).toHaveLength(2);
       expect(typeof olStyleFct === 'function').toBe(true);
     });
-    it('can write a OpenLayers PointSymbolizer', async () => {
+    it('can write an OpenLayers PointSymbolizer', async () => {
       let { output: olStyle } = await styleParser.writeStyle(point_simplepoint);
       olStyle = olStyle as OlStyle;
       expect(olStyle).toBeDefined();
@@ -427,7 +430,7 @@ describe('OlStyleParser implements StyleParser', () => {
       expect(olCircle.getRadius()).toBeCloseTo(expecSymb.radius as number);
       expect(olCircle.getFill().getColor()).toEqual(expecSymb.color);
     });
-    it('can write a OpenLayers IconSymbolizer', async () => {
+    it('can write an OpenLayers IconSymbolizer', async () => {
       let { output: olStyle } = await styleParser.writeStyle(point_icon);
       olStyle = olStyle as OlStyle;
       expect(olStyle).toBeDefined();
@@ -436,7 +439,6 @@ describe('OlStyleParser implements StyleParser', () => {
       const olIcon: OlStyleIcon = olStyle.getImage() as OlStyleIcon;
 
       expect(olIcon.getSrc()).toEqual(expecSymb.image);
-      expect(olIcon.getScale()).toBeCloseTo(expecSymb.size as number);
       // Rotation in openlayers is radians while we use degree
       expect(olIcon.getRotation()).toBeCloseTo((expecSymb.rotate as number) * Math.PI / 180);
       expect(olIcon.getOpacity()).toBeCloseTo(expecSymb.opacity as number);
@@ -460,7 +462,7 @@ describe('OlStyleParser implements StyleParser', () => {
       expect(olIcon.getSrc()).toEqual(dummyFeat.get('path'));
     });
   });
-  it('can write a OpenLayers RegularShape square', async () => {
+  it('can write an OpenLayers RegularShape square', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simplesquare);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -478,7 +480,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olSquareFill).toBeDefined();
     expect(olSquareFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape star', async () => {
+  it('can write an OpenLayers RegularShape star', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simplestar);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -500,7 +502,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olStarFill).toBeDefined();
     expect(olStarFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape triangle', async () => {
+  it('can write an OpenLayers RegularShape triangle', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simpletriangle);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -521,7 +523,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olTriangleFill).toBeDefined();
     expect(olTriangleFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape cross', async () => {
+  it('can write an OpenLayers RegularShape cross', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simplecross);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -543,7 +545,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olCrossFill).toBeDefined();
     expect(olCrossFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape x', async () => {
+  it('can write an OpenLayers RegularShape x', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simplex);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -565,7 +567,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olXFill).toBeDefined();
     expect(olXFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape shape://slash', async () => {
+  it('can write an OpenLayers RegularShape shape://slash', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simpleslash);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -586,7 +588,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olSlashFill).toBeDefined();
     expect(olSlashFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape shape://backslash', async () => {
+  it('can write an OpenLayers RegularShape shape://backslash', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simplebackslash);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -607,7 +609,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olBackSlashFill).toBeDefined();
     expect(olBackSlashFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape shape://vertline', async () => {
+  it('can write an OpenLayers RegularShape shape://vertline', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simplevertline);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -628,7 +630,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olVertlineFill).toBeDefined();
     expect(olVertlineFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape shape://horline', async () => {
+  it('can write an OpenLayers RegularShape shape://horline', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simplehorline);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -649,7 +651,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olHorlineFill).toBeDefined();
     expect(olHorlineFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape shape://carrow', async () => {
+  it('can write an OpenLayers RegularShape shape://carrow', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simplecarrow);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -670,7 +672,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olCarrowFill).toBeDefined();
     expect(olCarrowFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape shape://oarrow', async() => {
+  it('can write an OpenLayers RegularShape shape://oarrow', async() => {
     let { output: olStyle } = await styleParser.writeStyle(point_simpleoarrow);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -691,7 +693,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olOarrowFill).toBeDefined();
     expect(olOarrowFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape shape://dot', async () => {
+  it('can write an OpenLayers RegularShape shape://dot', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simpledot);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -706,7 +708,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olDot.getRadius()).toBeCloseTo(expecSymb.radius);
     expect(olDot.getFill().getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape shape://plus', async () => {
+  it('can write an OpenLayers RegularShape shape://plus', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simpleplus);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -728,7 +730,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olPlusFill).toBeDefined();
     expect(olPlusFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers RegularShape shape://times', async () => {
+  it('can write an OpenLayers RegularShape shape://times', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_simpletimes);
 
     olStyle = olStyle as OlStyle;
@@ -751,7 +753,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olTimesFill).toBeDefined();
     expect(olTimesFill.getColor()).toEqual(expecSymb.color);
   });
-  it('can write a OpenLayers Style based on a font glyph (WellKnownName starts with ttf://)', async () => {
+  it('can write an OpenLayers Style based on a font glyph (WellKnownName starts with ttf://)', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_fontglyph);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -771,7 +773,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olTextStroke).toBeDefined();
     expect(olTextStroke.getColor()).toEqual(expecSymb.strokeColor);
   });
-  it('can write a OpenLayers LineSymbolizer', async () => {
+  it('can write an OpenLayers LineSymbolizer', async () => {
     let { output: olStyle } = await styleParser.writeStyle(line_simpleline);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -784,7 +786,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olStroke.getWidth()).toBeCloseTo(expecSymb.width as number);
     expect(olStroke.getLineDash()).toEqual(expecSymb.dasharray);
   });
-  it('can write a OpenLayers PolygonSymbolizer', async () => {
+  it('can write an OpenLayers PolygonSymbolizer', async () => {
     let { output: olStyle } = await styleParser.writeStyle(polygon_transparentpolygon);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -806,7 +808,7 @@ describe('OlStyleParser implements StyleParser', () => {
 
     expect(olStroke.getLineDash()).toEqual(expecSymb.outlineDasharray);
   });
-  it('can write a OpenLayers PolygonSymbolizer with MarkSymbolizer as graphicFill', async () => {
+  it('can write an OpenLayers PolygonSymbolizer with MarkSymbolizer as graphicFill', async () => {
     let { output: olStyle } = await styleParser.writeStyle(polygon_graphicfill_mark);
     olStyle = olStyle as OlStyle;
     expect(olStyle).toBeDefined();
@@ -815,7 +817,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olFill).toBeDefined();
     expect(olFill.getColor()).toBeInstanceOf(CanvasPattern);
   });
-  it('can write a OpenLayers TextSymbolizer', async () => {
+  it('can write an OpenLayers TextSymbolizer', async () => {
     let { output: olStyle } = await styleParser.writeStyle(point_styledlabel);
     olStyle = olStyle as OlParserStyleFct;
     expect(olStyle).toBeDefined();


### PR DESCRIPTION
## Description

This drops the support for `size` in the `IconSymbolizer` as it was handled very inconvenient which led to confusion:

https://github.com/geostyler/geostyler/issues/1746
https://github.com/geostyler/geostyler-openlayers-parser/issues/624

The upcoming ol release will include `width` and `height` for the `ol/style/Icon` so we will be able to implement it correctly with the next ol version:

https://github.com/openlayers/openlayers/pull/14364

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
