### PR TITLE
Fix scale check

### DIFF
--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -727,13 +727,13 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
         let minScale = rule?.scaleDenominator?.min;
         let maxScale = rule?.scaleDenominator?.max;
         let isWithinScale = true;
-        if (minScale !== undefined || maxScale !== undefined) {
+        if (minScale || maxScale) {
           minScale = isGeoStylerFunction(minScale) ? OlStyleUtil.evaluateNumberFunction(minScale) : minScale;
           maxScale = isGeoStylerFunction(maxScale) ? OlStyleUtil.evaluateNumberFunction(maxScale) : maxScale;
-          if (minScale !== undefined && scale < minScale) {
+          if (minScale && scale < minScale) {
             isWithinScale = false;
           }
-          if (maxScale !== undefined && scale >= maxScale) {
+          if (maxScale && scale >= maxScale) {
             isWithinScale = false;
           }
         }


### PR DESCRIPTION
## Description

Fixes the scale check for `null` values. Previously the scale check would lead to an out of scale determination if `max` or `min` was set to null.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!

@geostyler/devs Please review.