### PR TITLE
Fix parsing of css font strings

### DIFF
--- a/data/styles/point_styledLabel_static.ts
+++ b/data/styles/point_styledLabel_static.ts
@@ -14,7 +14,9 @@ const pointStyledLabel: Style = {
         offset: [0, 5],
         haloColor: '#000000',
         haloWidth: 5,
-        rotate: 45
+        rotate: 45,
+        fontStyle: 'normal',
+        fontWeight: 'normal'
       }]
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "color-name": "^1.1.4",
+        "css-font-parser": "^2.0.0",
         "geostyler-style": "^7.2.0"
       },
       "devDependencies": {
@@ -4806,6 +4807,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-font-parser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-parser/-/css-font-parser-2.0.0.tgz",
+      "integrity": "sha512-YjgBiAq5rFNXfsPHofaEZwsUbCoSK0avstS76BSqNyVCM7+oiO44wZxbtq6YFSaQafCG0llS/f79oqlsmzaBJg=="
+    },
     "node_modules/csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
@@ -4815,7 +4821,7 @@
     "node_modules/cssfontparser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
-      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
       "dev": true
     },
     "node_modules/cssom": {
@@ -16943,6 +16949,11 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
+    "css-font-parser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-parser/-/css-font-parser-2.0.0.tgz",
+      "integrity": "sha512-YjgBiAq5rFNXfsPHofaEZwsUbCoSK0avstS76BSqNyVCM7+oiO44wZxbtq6YFSaQafCG0llS/f79oqlsmzaBJg=="
+    },
     "csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
@@ -16952,7 +16963,7 @@
     "cssfontparser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
-      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
       "dev": true
     },
     "cssom": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "color-name": "^1.1.4",
+    "css-font-parser": "^2.0.0",
     "geostyler-style": "^7.2.0"
   },
   "peerDependencies": {

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -368,7 +368,7 @@ describe('OlStyleParser implements StyleParser', () => {
         const fontFamily = [
           ['arial', 'sans-serif'],
           ['Georgia', 'serif'],
-          ['"Neue Helvetica"', 'Helvetica', 'sans-serif']
+          ['Neue Helvetica', 'Helvetica', 'sans-serif']
         ];
         const font1 = `bold 5px ${fontFamily[0].join(', ')}`;
         const font2 = `italic bold 12px/30px ${fontFamily[1].join(', ')}`;

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -1,3 +1,5 @@
+import { parseFont } from 'css-font-parser';
+
 import {
   CapType,
   FillSymbolizer,
@@ -403,24 +405,25 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
     const allowOverlap = olTextStyle.getOverflow() ? olTextStyle.getOverflow() : undefined;
     const text = olTextStyle.getText();
     const label = Array.isArray(text) ? text[0] : text;
-    let fontStyleWeightSize: string;
-    let fontSizePart: string[];
     let fontSize: number = Infinity;
     let fontFamily: string[]|undefined = undefined;
+    let fontWeight: 'normal' | 'bold' = 'normal';
+    let fontStyle: 'normal' | 'italic' | 'oblique' = 'normal';
 
     if (font) {
-      const fontSplit = font.split('px');
-      // font-size is always the first part of font-size/line-height
-      fontStyleWeightSize = fontSplit[0].trim();
-
-      fontSizePart = fontStyleWeightSize.split(' ');
-      // The last element contains font size
-      fontSize = parseInt(fontSizePart[fontSizePart.length - 1], 10);
-      const fontFamilyPart: string = fontSplit.length === 2 ?
-        fontSplit[1] : fontSplit[2];
-      fontFamily = fontFamilyPart.split(',').map((fn: string) => {
-        return fn.startsWith(' ') ? fn.slice(1) : fn;
-      });
+      const fontObj = parseFont(font);
+      if (fontObj['font-weight']) {
+        fontWeight = fontObj['font-weight'] as 'normal' | 'bold';
+      }
+      if (fontObj['font-size']) {
+        fontSize = parseInt(fontObj['font-size'], 10);
+      }
+      if (fontObj['font-family']) {
+        fontFamily = fontObj['font-family'];
+      }
+      if (fontObj['font-style']) {
+        fontStyle = fontObj['font-style'] as 'normal' | 'italic' | 'oblique';
+      }
     }
 
     return {
@@ -430,6 +433,8 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
       color: olFillStyle ? OlStyleUtil.getHexColor(olFillStyle.getColor() as string) : undefined,
       size: isFinite(fontSize) ? fontSize : undefined,
       font: fontFamily,
+      fontWeight,
+      fontStyle,
       offset: (offsetX !== undefined) && (offsetY !== undefined) ? [offsetX, offsetY] : [0, 0],
       haloColor: olStrokeStyle && olStrokeStyle.getColor() ?
         OlStyleUtil.getHexColor(olStrokeStyle.getColor() as string) : undefined,

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -152,7 +152,7 @@ class OlStyleUtil {
 
     const size = symbolizer.size;
     const font = symbolizer.font;
-    return fontWeight + ' ' + fontStyle + ' ' + size + 'px ' + font;
+    return fontWeight + ' ' + fontStyle + ' ' + size + 'px ' + font?.join(', ');
   }
 
 


### PR DESCRIPTION
## Description

This fixes the parsing of the css font string coming from openlayers.
Before this change, some font properties were not or wrongly detected, as the parsing did not follow the spec.

@geostyler/devs please review

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
