### PR TITLE
Handle RegEx with flags

### DIFF
--- a/src/Util/OlStyleUtil.spec.ts
+++ b/src/Util/OlStyleUtil.spec.ts
@@ -329,5 +329,14 @@ describe('OlStyleUtil', () => {
       const match = OlStyleUtil.evaluateBooleanFunction(regExFn, feat);
       expect(match).toEqual(true);
     });
+
+    it('regex with flag matches', () => {
+
+      const feat = new OlFeature();
+      const regExFn: GeoStylerBooleanFunction = {name: 'strMatches', args: ['bank', '/(bus|bank)/i']};
+
+      const match = OlStyleUtil.evaluateBooleanFunction(regExFn, feat);
+      expect(match).toEqual(true);
+    });
   });
 });

--- a/src/Util/OlStyleUtil.spec.ts
+++ b/src/Util/OlStyleUtil.spec.ts
@@ -1,7 +1,7 @@
 import OlStyleUtil, { DUMMY_MARK_SYMBOLIZER_FONT } from './OlStyleUtil';
 import OlFeature from 'ol/Feature';
 import OlGeomPoint from 'ol/geom/Point';
-import { MarkSymbolizer, TextSymbolizer } from 'geostyler-style';
+import { MarkSymbolizer, TextSymbolizer, GeoStylerBooleanFunction } from 'geostyler-style';
 
 describe('OlStyleUtil', () => {
 
@@ -315,4 +315,19 @@ describe('OlStyleUtil', () => {
     });
   });
 
+  describe('#evaluateBooleanFunction', () => {
+
+    it('is defined', () => {
+      expect(OlStyleUtil.evaluateBooleanFunction).toBeDefined();
+    });
+
+    it('regex matches', () => {
+
+      const feat = new OlFeature();
+      const regExFn: GeoStylerBooleanFunction = {name: 'strMatches', args: ['bank', '/(bus|bank)/']};
+
+      const match = OlStyleUtil.evaluateBooleanFunction(regExFn, feat);
+      expect(match).toEqual(true);
+    });
+  });
 });

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -349,7 +349,8 @@ class OlStyleUtil {
       case 'strEqualsIgnoreCase':
         return (args[0] as string).toLowerCase() === (args[1] as string).toLowerCase() ;
       case 'strMatches':
-        return new RegExp(args[1] as string).test(args[0] as string);
+        const regEx = (args[1] as string).replace(/^\/|\/$/g, '');
+        return new RegExp(regEx).test(args[0] as string);
       case 'strStartsWith':
         return (args[0] as string).startsWith(args[1] as string);
       default:

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -349,8 +349,13 @@ class OlStyleUtil {
       case 'strEqualsIgnoreCase':
         return (args[0] as string).toLowerCase() === (args[1] as string).toLowerCase() ;
       case 'strMatches':
-        const regEx = (args[1] as string).replace(/^\/|\/$/g, '');
-        return new RegExp(regEx).test(args[0] as string);
+        const regEx = (args[1] as string);
+        const regexArray = regEx.match(/\/(.*?)\/([gimy]{0,4})$/);
+        if (regexArray && regexArray.length === 3){
+          return new RegExp(regexArray[1], regexArray[2]).test(args[0] as string);
+        } else {
+          return false;
+        }
       case 'strStartsWith':
         return (args[0] as string).startsWith(args[1] as string);
       default:


### PR DESCRIPTION
## Description

A MapServer class such as in the tests [here](https://github.com/geostyler/geostyler-mapfile-parser/blob/17c74e1001802891c840c66729f0807a4dfbc412/data/mapfiles/point_st_sample_style_tags_single_filter_list.map#L12) :

```
  CLASS
    EXPRESSION {bus,bank}
```

Converts to the following GeoStyler style (see [here](https://github.com/geostyler/geostyler-mapfile-parser/blob/17c74e1001802891c840c66729f0807a4dfbc412/data/styles/point_st_sample_style_tags_single_filter_list.ts#L12)):

```
    filter: [
      '==', {
        name: 'strMatches',
        args: [{
          name: 'property',
          args: ['name']
        }, '/(bus|bank)/']
```

When this is converted to an OpenLayers style function using the code in [OlStyleUtil](https://github.com/geostyler/geostyler-openlayers-parser/blob/27a47d211a149272b06e45d4a9ee4dde4aff6726/src/Util/OlStyleUtil.ts#L352)

```
      case 'strMatches':
        return new RegExp(args[1] as string).test(args[0] as string);
```

The forward slashes are escaped and no features are matched:

```
r = new RegExp(args[1])
/\/(bus|bank)\//

// this is what we want
r = new RegExp(/(bus|bank)/)
/(bus|bank)/

// but as a string is passed they are escaped:

r = new RegExp('/(bus|bank)/')
/\/(bus|bank)\//

```

This pull request strips the start and trailing '\' from the string. As discussed with @jansule there may be issues if flags are stored in GeoStyler regex strings e.g. `/pattern/gmi`. To support this requires passing `'gmi'` to the flags parameter of the RegEx constructor e.g. ` new RegExp('pattern', 'gmi')`. This is handled in this pull request. 

The following approach works for all cases `r = new RegExp(eval(args[1]))` but using `eval` is problematic. 
Initially I thought `String.raw` was an option but this doesn't work correctly. 

## Related issues or pull requests

Originally added as an issue at https://github.com/geostyler/geostyler-mapfile-parser/issues/247

## Pull request type

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [X] Bugfix

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [X] I am unsure (no worries, we'll find out)

## Checklist

- [X] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [X] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [X] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [X] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!

