### PR TITLE
Clone style to avoid manipulation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testEnvironment: 'jsdom',
+  testEnvironment: './jest/Environment.js',
   moduleFileExtensions: [
     'ts',
     'js'

--- a/jest/Environment.js
+++ b/jest/Environment.js
@@ -1,0 +1,12 @@
+import Environment from 'jest-environment-jsdom';
+
+/**
+ * A custom environment to set the TextEncoder.
+ */
+module.exports = class CustomTestEnvironment extends Environment {
+  async setup() {
+    await super.setup();
+    // https://github.com/jsdom/jsdom/issues/3363
+    this.global.structuredClone = structuredClone;
+  }
+};

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -758,15 +758,15 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
         }
 
         if (isWithinScale && matchesFilter) {
-          rule.symbolizers.forEach((symb: Symbolizer): void => {
+          rule.symbolizers.forEach((symb: Symbolizer) => {
             if (symb.visibility === false) {
-              return;
+              styles.push(null);
             }
 
             if (isGeoStylerBooleanFunction(symb.visibility)) {
               const visibility = OlStyleUtil.evaluateBooleanFunction(symb.visibility);
               if (!visibility) {
-                return;
+                styles.push(null);
               }
             }
 

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -586,9 +586,10 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
    */
   writeStyle(geoStylerStyle: Style): Promise<WriteStyleResult<OlStyle | OlStyle[] | OlParserStyleFct>> {
     return new Promise<WriteStyleResult>((resolve) => {
-      const unsupportedProperties = this.checkForUnsupportedProperties(geoStylerStyle);
+      const clonedStyle = structuredClone(geoStylerStyle);
+      const unsupportedProperties = this.checkForUnsupportedProperties(clonedStyle);
       try {
-        const olStyle = this.getOlStyleTypeFromGeoStylerStyle(geoStylerStyle);
+        const olStyle = this.getOlStyleTypeFromGeoStylerStyle(clonedStyle);
         resolve({
           output: olStyle,
           unsupportedProperties,
@@ -757,15 +758,15 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
         }
 
         if (isWithinScale && matchesFilter) {
-          rule.symbolizers.forEach((symb: Symbolizer) => {
+          rule.symbolizers.forEach((symb: Symbolizer): void => {
             if (symb.visibility === false) {
-              return null;
+              return;
             }
 
             if (isGeoStylerBooleanFunction(symb.visibility)) {
               const visibility = OlStyleUtil.evaluateBooleanFunction(symb.visibility);
               if (!visibility) {
-                return null;
+                return;
               }
             }
 

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -719,7 +719,7 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
    * @return An OlParserStyleFct
    */
   geoStylerStyleToOlParserStyleFct(geoStylerStyle: Style): OlParserStyleFct {
-    const rules = geoStylerStyle.rules;
+    const rules = structuredClone(geoStylerStyle.rules);
     const olStyle = (feature: any, resolution: number): any[] => {
       const styles: any[] = [];
 


### PR DESCRIPTION
## Description

This PR makes use of `structuredClone` when writing the style to avoid manipulation of the input object.

It also pushes `null` to the styles array when the `visibilty` of a `symbolizer` is set to `false`. 

## Related issues or pull requests

Fixes #740 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
