### PR TITLE
Use `fillOpacity` instead of `opacity` for `FillSymbolizer`

### DIFF
--- a/data/styles/polygon_transparentpolygon.ts
+++ b/data/styles/polygon_transparentpolygon.ts
@@ -8,7 +8,7 @@ const polygonTransparentPolygon: Style = {
       symbolizers: [{
         kind: 'Fill',
         color: '#000080',
-        opacity: 0.5,
+        fillOpacity: 0.5,
         outlineColor: '#ffffff',
         outlineDasharray: [10, 15],
         outlineOpacity: 0.7,

--- a/data/styles/unsupported_properties.ts
+++ b/data/styles/unsupported_properties.ts
@@ -8,7 +8,7 @@ const unsupportedProperties: Style = {
       symbolizers: [{
         kind: 'Fill',
         color: '#F1337F',
-        fillOpacity: 0.5
+        opacity: 0.5
       }]
     }
   ]

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -809,7 +809,7 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olFill).toBeDefined();
 
     const expecSymbFillCol: string = expecSymb.color as string;
-    const expecSymbFillOpac: number = expecSymb.opacity as number;
+    const expecSymbFillOpac: number = expecSymb.fillOpacity as number;
     expect(olFill.getColor()).toEqual(OlStyleUtil.getRgbaColor(expecSymbFillCol, expecSymbFillOpac));
 
     expect(olStroke.getLineDash()).toEqual(expecSymb.outlineDasharray);
@@ -1199,8 +1199,8 @@ describe('OlStyleParser implements StyleParser', () => {
     const unsupportedGot = {
       Symbolizer: {
         FillSymbolizer: {
-          fillOpacity: {
-            info: 'Use opacity instead.',
+          opacity: {
+            info: 'Use fillOpacity instead.',
             support: 'none'
           }
         }

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -76,9 +76,9 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
       },
       FillSymbolizer: {
         antialias: 'none',
-        fillOpacity: {
+        opacity: {
           support: 'none',
-          info: 'Use opacity instead.'
+          info: 'Use fillOpacity instead.'
         }
       },
       IconSymbolizer: {
@@ -368,8 +368,8 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
     if (olFillStyle) {
       symbolizer.color = OlStyleUtil.getHexColor(olFillStyle.getColor() as string);
     }
-    if (olStrokeStyle) {
-      symbolizer.opacity = OlStyleUtil.getOpacity(olFillStyle.getColor() as string);
+    if (olFillStyle) {
+      symbolizer.fillOpacity = OlStyleUtil.getOpacity(olFillStyle.getColor() as string);
     }
     if (olStrokeStyle) {
       symbolizer.outlineColor = OlStyleUtil.getHexColor(olStrokeStyle.getColor() as string);
@@ -1285,7 +1285,7 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
     }
 
     const color = symbolizer.color as string;
-    const opacity = symbolizer.opacity as number;
+    const opacity = symbolizer.fillOpacity as number;
     const fColor = color && Number.isFinite(opacity)
       ? OlStyleUtil.getRgbaColor(color, opacity)
       : color;


### PR DESCRIPTION
## Description

This fixes the handling of the opacity of the fill color in a `FillSymbolizer`. As per `geostyler-style` this information should be stored in [`fillOpacity`](https://github.com/geostyler/geostyler-style/blob/master/style.ts#L220) and not in [`opacity`](https://github.com/geostyler/geostyler-style/blob/master/style.ts#L138) as this is an overall opacity of the whole symbolizer.

This also ensures to be in sync with other parsers like the SLDParser.

