### PR TITLE
fix: parsing of property functions in filter args

### DIFF
--- a/data/styles/filter_comparison_propertyFunction.ts
+++ b/data/styles/filter_comparison_propertyFunction.ts
@@ -1,0 +1,80 @@
+import {Fproperty, Style} from "geostyler-style";
+
+const value: Fproperty = {
+  name: "property",
+  args: [
+    "value"
+  ]
+};
+
+const min: Fproperty = {
+  name: "property",
+  args: [
+    "min"
+  ]
+}
+
+const max: Fproperty = {
+  name: "property",
+  args: [
+    "max"
+  ]
+}
+
+const filterComparisonPropertyFunction: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: "between min and max",
+      filter: [
+        "&&",
+        [
+          ">=",
+          value, min
+
+        ],
+        [
+          "<=",
+          value,
+          max
+        ]
+      ],
+      symbolizers: [
+        {
+          kind: "Text",
+          label: "between min and max",
+        }
+      ]
+    },
+    {
+      name: 'above max',
+      filter: [
+        ">",
+        value,
+        max
+      ],
+      symbolizers: [
+        {
+          kind: "Text",
+          label: "above max"
+        }
+      ]
+    },
+    {
+      name: "below min",
+      filter: [
+        "<",
+        value,
+        min
+      ],
+      symbolizers: [
+        {
+          kind: "Text",
+          label: "below min",
+        }
+      ]
+    }
+  ]
+}
+
+export default filterComparisonPropertyFunction;

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -54,6 +54,7 @@ import function_case from '../data/styles/function_case';
 import text_placement_point from '../data/styles/text_placement_point';
 import text_placement_line from '../data/styles/text_placement_line';
 import text_placement_line_center from '../data/styles/text_palcement_line_center';
+import filter_comparison_propertyFunction from "../data/styles/filter_comparison_propertyFunction";
 
 import ol_function_marksymbolizer from '../data/olStyles/function_markSymbolizer';
 import ol_function_nested_fillsymbolizer from '../data/olStyles/function_nested_fillSymbolizer';
@@ -1265,6 +1266,41 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(geoStylerStyle.__geoStylerStyle).toEqual(function_boolean);
     expect(targetStyle1[0]).toEqual(ol_function_boolean_fillsymbolizer1);
     expect(targetStyle2[0]).toEqual(ol_function_boolean_fillsymbolizer2);
+  });
+
+  it('can write a comparison filter where the first and second arguments are property functions', async () => {
+    let { output: geoStylerStyle } = await styleParser.writeStyle(filter_comparison_propertyFunction);
+    expect(geoStylerStyle).toBeDefined();
+    expect(typeof geoStylerStyle === 'function').toBe(true);
+    geoStylerStyle = geoStylerStyle as OlParserStyleFct;
+    const inBetweenLabel = (filter_comparison_propertyFunction.rules[0].symbolizers[0] as TextSymbolizer).label;
+    const aboveLabel = (filter_comparison_propertyFunction.rules[1].symbolizers[0] as TextSymbolizer).label;
+    const belowLabel = (filter_comparison_propertyFunction.rules[2].symbolizers[0] as TextSymbolizer).label;
+
+    const inBetweenFeat = new OlFeature({
+      value: 0.8,
+      max: 1,
+      min: 0.5
+    });
+    const aboveFeat = new OlFeature({
+      value: 2,
+      max: 1,
+      min: 0.5
+    });
+    const belowFeat = new OlFeature({
+      value: 0.2,
+      max: 1,
+      min: 0.5
+    });
+
+    const inBetweenOLStyle  = geoStylerStyle(inBetweenFeat);
+    const aboveOLStyle = geoStylerStyle(aboveFeat);
+    const belowOLStyle = geoStylerStyle(belowFeat);
+
+    expect(inBetweenOLStyle[0].getText().getText()).toBe(inBetweenLabel);
+    expect(aboveOLStyle[0].getText().getText()).toBe(aboveLabel);
+    expect(belowOLStyle[0].getText().getText()).toBe(belowLabel);
+
   });
 
   it('adds unsupportedProperties to the write output', async () => {

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -898,7 +898,7 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
         }
         let arg2: any;
         if (isGeoStylerFunction(filter[2])) {
-          arg2 = feature.get(OlStyleUtil.evaluateFunction(filter[2], feature));
+          arg2 = OlStyleUtil.evaluateFunction(filter[2], feature);
         } else {
           arg2 = filter[2];
         }


### PR DESCRIPTION
## Description

Fixes a bug when both arguments to a comparison filter are property functions. The parser would extract the property from the feature and then use the value as a key for the feature again. e.g. feature.get(feature.get('x'));

## Related issues or pull requests

#791 

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
