### PR TITLE
bugfix: check if Array instead of number

### DIFF
--- a/data/olStyles/point_simpleoffset.ts
+++ b/data/olStyles/point_simpleoffset.ts
@@ -1,0 +1,15 @@
+import OlStyle from 'ol/style/Style';
+import OlStyleCircle from 'ol/style/Circle';
+import OlStyleFill from 'ol/style/Fill';
+
+const olSimplePoint = new OlStyle({
+  image: new OlStyleCircle({
+    radius: 6,
+    fill: new OlStyleFill({
+      color: '#FF0000'
+    }),
+    displacement: [1,1]
+  })
+});
+
+export default olSimplePoint;

--- a/data/styles/point_simpleoffset.ts
+++ b/data/styles/point_simpleoffset.ts
@@ -1,0 +1,19 @@
+import { Style } from 'geostyler-style';
+
+const pointSimpleOffset: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'circle',
+        color: '#FF0000',
+        radius: 6,
+        offset: [1, 1]
+      }]
+    }
+  ]
+};
+
+export default pointSimpleOffset;

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -13,6 +13,7 @@ import OlFeature from 'ol/Feature';
 import OlStyleParser, { OlParserStyleFct } from './OlStyleParser';
 
 import point_simplepoint from '../data/styles/point_simplepoint';
+import point_simpleoffset from '../data/styles/point_simpleoffset';
 import point_icon from '../data/styles/point_icon';
 import point_icon_sprite from '../data/styles/point_icon_sprite';
 import point_dynamic_icon from '../data/styles/point_dynamic_icon';
@@ -58,6 +59,7 @@ import filter_comparison_propertyFunction from '../data/styles/filter_comparison
 import ol_function_marksymbolizer from '../data/olStyles/function_markSymbolizer';
 import ol_function_nested_fillsymbolizer from '../data/olStyles/function_nested_fillSymbolizer';
 import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
+import ol_point_simpleoffset from '../data/olStyles/point_simpleoffset';
 import ol_point_icon from '../data/olStyles/point_icon';
 import ol_point_icon_sprite from '../data/olStyles/point_icon_sprite';
 import ol_point_simplesquare from '../data/olStyles/point_simplesquare';
@@ -154,6 +156,11 @@ describe('OlStyleParser implements StyleParser', () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simplepoint);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(point_simplepoint);
+    });
+    it('can read an OpenLayers PointSymbolizer with displacement', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_simpleoffset);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(point_simpleoffset);
     });
     it('can read an OpenLayers IconSymbolizer', async () => {
       const { output: geoStylerStyle } = await styleParser.readStyle(ol_point_icon);
@@ -458,6 +465,17 @@ describe('OlStyleParser implements StyleParser', () => {
       expect(olCircle).toBeDefined();
       expect(olCircle.getRadius()).toBeCloseTo(expecSymb.radius as number);
       expect(olCircle.getFill()?.getColor()).toEqual(expecSymb.color);
+    });
+    it('can write an OpenLayers PointSymbolizer with displacement', async () => {
+      let { output: olStyle } = await styleParser.writeStyle(point_simpleoffset);
+      olStyle = olStyle as OlStyle;
+      expect(olStyle).toBeDefined();
+
+      const expecSymb = point_simpleoffset.rules[0].symbolizers[0] as MarkSymbolizer;
+      const olCircle: OlStyleCircle = olStyle.getImage() as OlStyleCircle;
+
+      expect(olCircle).toBeDefined();
+      expect(olCircle.getDisplacement()).toEqual(expecSymb.offset);
     });
     it('can write an OpenLayers IconSymbolizer', async () => {
       let { output: olStyle } = await styleParser.writeStyle(point_icon);

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -1046,7 +1046,7 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
       radius: radius ?? 5,
       rotation: typeof(markSymbolizer.rotate) === 'number' ? markSymbolizer.rotate * Math.PI / 180 : undefined,
       stroke: stroke,
-      displacement: typeof(markSymbolizer.offset) === 'number' ? markSymbolizer.offset : undefined
+      displacement: Array.isArray(markSymbolizer.offset) ? markSymbolizer.offset.map(Number) : undefined
     };
 
     switch (markSymbolizer.wellKnownName) {


### PR DESCRIPTION
## Description

Check if offset is an array instead of number as it's always an array of numbers. By checking for array the offset will be in the openlayers style as displacement.

## Related issues or pull requests

https://github.com/geostyler/geostyler-openlayers-parser/issues/799

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [x] I'm lost; why do I have to check so many boxes? Please help!
