### PR TITLE
chore(deps): bump geostyler-style to 10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "css-font-parser": "^2.0.0",
-        "geostyler-style": "^9.0.1"
+        "geostyler-style": "^10.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.9",
@@ -8662,9 +8662,10 @@
       }
     },
     "node_modules/geostyler-style": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-9.0.1.tgz",
-      "integrity": "sha512-gQ5hQPS1NTBXyVAI1GDeg6nLgV1tl1vYarYk/YJczcAHoNy3/kYVY0TTdNxF52NTuRoN2l77KMgQy+JDLu69Dg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-10.0.0.tgz",
+      "integrity": "sha512-Gafn436MLApVvE1hsKrJ40KuH+6IUWM9V88IOuFxvZzsosn4a56ZJCXHXznN3usK/6ZZtmD0M5gO8ZhbB1wcwQ==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.6.0",
         "npm": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "css-font-parser": "^2.0.0",
-    "geostyler-style": "^9.0.1"
+    "geostyler-style": "^10.0.0"
   },
   "peerDependencies": {
     "ol": ">=7.4"


### PR DESCRIPTION
## Description

Bumps geostyler-style to its latest version `10.0.0`.

## Related issues or pull requests

none

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [x] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
