### PR TITLE
fix(OlFlatStyleParser): properly parse expressions in FlatRule filters

### DIFF
--- a/data/olFlatStyles/filter_nestedFilter.ts
+++ b/data/olFlatStyles/filter_nestedFilter.ts
@@ -1,0 +1,30 @@
+import { Rule } from 'ol/style/flat';
+
+const filterNestedFilter: Rule[] = [
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'state'], 'germany'],
+      [
+        'any',
+        ['>=', ['get', 'population'], 100000],
+        ['<', ['get', 'population'], 200000]
+      ],
+      [
+        '!',
+        ['==', ['get', 'name'], 'Schalke']
+      ]
+    ],
+    style: {
+      'circle-radius': 10,
+      'circle-fill-color': '#FF0000'
+    }
+  }, {
+    style: {
+      'circle-radius': 6,
+      'circle-fill-color': '#FF0000'
+    }
+  }
+];
+
+export default filterNestedFilter;

--- a/src/OlFlatStyleParser.spec.ts
+++ b/src/OlFlatStyleParser.spec.ts
@@ -9,6 +9,7 @@ import pointIconSimple from '../data/styles/point_icon_simple';
 import pointSimplePoint from '../data/styles/point_simplepoint';
 import multiTwoRulesSimplepoint from '../data/styles/multi_twoRulesSimplepoint';
 import filterSimpleFilter from '../data/styles/filter_simpleFilter';
+import filterNestedFilter from '../data/styles/filter_nestedFilter';
 
 import ol_polygon_simple from '../data/olFlatStyles/polygon_simple';
 import ol_line_simpleline from '../data/olFlatStyles/line_simpleline';
@@ -17,6 +18,7 @@ import ol_point_icon_simple from '../data/olFlatStyles/point_icon_simple';
 import ol_point_simplepoint from '../data/olFlatStyles/point_simplepoint';
 import ol_multi_twoRulesSimplepoint from '../data/olFlatStyles/multi_twoRulesSimplepoint';
 import ol_filter_simpleFilter from '../data/olFlatStyles/filter_simpleFilter';
+import ol_filter_nestedFilter from '../data/olFlatStyles/filter_nestedFilter';
 
 it('OlFlatStyleParser is defined', () => {
   expect(OlFlatStyleParser).toBeDefined();
@@ -74,6 +76,12 @@ describe('OlFlatStyleParser implements StyleParser', () => {
       const { output: geostylerStyle } = await styleParser.readStyle(ol_filter_simpleFilter);
       expect(geostylerStyle).toBeDefined();
       expect(geostylerStyle).toEqual(filterSimpleFilter);
+    });
+
+    it('reads a nested filter', async () => {
+      const { output: geostylerStyle } = await styleParser.readStyle(ol_filter_nestedFilter);
+      expect(geostylerStyle).toBeDefined();
+      expect(geostylerStyle).toEqual(filterNestedFilter);
     });
   });
 });

--- a/src/Util/OlFlatStyleUtil.spec.ts
+++ b/src/Util/OlFlatStyleUtil.spec.ts
@@ -1,5 +1,5 @@
 import { FlatStyle, Rule } from 'ol/style/flat';
-import OlFlatStyleUtil from './OlFlatStyleUtil';
+import OlFlatStyleUtil, { FilterExpression } from './OlFlatStyleUtil';
 import { ColorLike } from 'ol/colorlike';
 import { Color } from 'ol/color';
 
@@ -20,6 +20,10 @@ const flatRuleArray: Rule[] = [
 ];
 
 const expression = ['==', 'name', 'value'];
+
+const comparisonFilter: FilterExpression = ['==', ['get', 'name'], 'value'];
+
+const nonComparisonFilter: FilterExpression = ['all', false, true];
 
 const primitives = {
   // eslint-disable-next-line id-blacklist
@@ -142,6 +146,48 @@ describe('OlFlatStyleUtil', () => {
       Object.keys(objects).forEach((key) => {
         const isExpression = OlFlatStyleUtil.isExpression(objects[key]);
         expect(isExpression).toBe(false);
+      });
+    });
+  });
+
+  describe('isFilter', () => {
+    it('returns true for a filter', () => {
+      const isFilter = OlFlatStyleUtil.isFilter(comparisonFilter);
+      expect(isFilter).toBe(true);
+    });
+    it('returns false for primitives', () => {
+      Object.keys(primitives).forEach((key) => {
+        const isFilter = OlFlatStyleUtil.isFilter(primitives[key]);
+        expect(isFilter).toBe(false);
+      });
+    });
+    it('returns false for objects and non-filter arrays', () => {
+      Object.keys(objects).forEach((key) => {
+        const isFilter = OlFlatStyleUtil.isFilter(objects[key]);
+        expect(isFilter).toBe(false);
+      });
+    });
+  });
+
+  describe('isComparisonFilter', () => {
+    it('returns true for a comparison filter', () => {
+      const isComparisonFilter = OlFlatStyleUtil.isComparisonFilter(comparisonFilter);
+      expect(isComparisonFilter).toBe(true);
+    });
+    it('returns false for primitives', () => {
+      Object.keys(primitives).forEach((key) => {
+        const isComparisonFilter = OlFlatStyleUtil.isComparisonFilter(primitives[key]);
+        expect(isComparisonFilter).toBe(false);
+      });
+    });
+    it('returns false for non-comparison-filter arrays', () => {
+      const isComparisonFilter = OlFlatStyleUtil.isComparisonFilter(nonComparisonFilter);
+      expect(isComparisonFilter).toBe(false);
+    });
+    it('returns false for objects and non-filter arrays', () => {
+      Object.keys(objects).forEach((key) => {
+        const isComparisonFilter = OlFlatStyleUtil.isComparisonFilter(objects[key]);
+        expect(isComparisonFilter).toBe(false);
       });
     });
   });


### PR DESCRIPTION
## Description

This improves parsing expressions in FlatRule filters. In addition to filter expressions, common expressions are now also being parsed. Also, if the first argument of a comparison filter is a 'get' expression, we directly extract the propertyName.

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
