### PR TITLE
Use bun in CI workflows

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -6,42 +6,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20.x, 22.x]
-
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-
-    - name: Cache Node.js modules 💾
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
+    - name: Set up bun
+      uses: oven-sh/setup-bun@v2
 
     - name: Install dependencies ⏬
-      run: npm install
+      run: bun install
 
     - name: Lint code 💄
-      run: npm run lint
+      run: bun run lint
 
     - name: Typecheck code 🤖
-      run: npm run typecheck
+      run: bun run typecheck
 
     - name: Test code ✅
-      run: npm run test
+      run: bun run test
 
     - name: Build artifacts 🏗️
-      run: npm run build
+      run: bun run build
 
     - name: Publish to coveralls ⭐
       # coverage/lcov.info was generated in the previous npm run build step

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -30,6 +30,4 @@ jobs:
 
     - name: Publish to coveralls ⭐
       # coverage/lcov.info was generated in the previous npm run build step
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: coverallsapp/github-action@v2

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -33,6 +33,4 @@ jobs:
 
     - name: Publish to coveralls ⭐
       # coverage/lcov.info was generated in the previous npm run build step
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: coverallsapp/github-action@v2

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -3,7 +3,7 @@ name: Test Push to main
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -1,4 +1,4 @@
-name: Test Push to Master
+name: Test Push to main
 
 on:
   push:
@@ -9,42 +9,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20.x, 22.x]
-
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-
-    - name: Cache Node.js modules 💾
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
+    - name: Set up bun
+      uses: oven-sh/setup-bun@v2
 
     - name: Install dependencies ⏬
-      run: npm install
+      run: bun install
 
     - name: Lint code 💄
-      run: npm run lint
+      run: bun run lint
 
     - name: Typecheck code 🤖
-      run: npm run typecheck
+      run: bun run typecheck
 
     - name: Test code ✅
-      run: npm run test
+      run: bun run test
 
     - name: Build artifacts 🏗️
-      run: npm run build
+      run: bun run build
 
     - name: Publish to coveralls ⭐
       # coverage/lcov.info was generated in the previous npm run build step


### PR DESCRIPTION
## Description

This PR makes it so that:
* the workflows running for PRs and the `main` branch now use `bun` instead of NPM
* the workflow intended to run for `main` was still targeting the `master` branch


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): changes to CI workflows
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
