### PR TITLE
fix(OlFlatStyleParser): set fillOpacity on circle styles

### DIFF
--- a/data/olFlatStyles/point_opaquepoint.ts
+++ b/data/olFlatStyles/point_opaquepoint.ts
@@ -1,0 +1,9 @@
+import { FlatStyle } from 'ol/style/flat';
+
+const pointOpaquePoint: FlatStyle = {
+  'circle-stroke-color': '#FF0000FF',
+  'circle-fill-color': '#00FF0000',
+  'circle-radius': 6
+};
+
+export default pointOpaquePoint;

--- a/data/styles/point_opaquepoint.ts
+++ b/data/styles/point_opaquepoint.ts
@@ -1,0 +1,21 @@
+import { Style } from 'geostyler-style';
+
+const pointOpaquePoint: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'circle',
+        strokeColor: '#FF0000',
+        strokeOpacity: 1,
+        color: '#00FF00',
+        fillOpacity: 0,
+        radius: 6
+      }]
+    }
+  ]
+};
+
+export default pointOpaquePoint;

--- a/src/OlFlatStyleParser.spec.ts
+++ b/src/OlFlatStyleParser.spec.ts
@@ -7,6 +7,7 @@ import lineSimpleLine from '../data/styles/line_simpleline';
 import textPlacementLine from '../data/styles/text_placement_line';
 import pointIconSimple from '../data/styles/point_icon_simple';
 import pointSimplePoint from '../data/styles/point_simplepoint';
+import pointOpaquePoint from '../data/styles/point_opaquepoint';
 import multiTwoRulesSimplepoint from '../data/styles/multi_twoRulesSimplepoint';
 import filterSimpleFilter from '../data/styles/filter_simpleFilter';
 import filterNestedFilter from '../data/styles/filter_nestedFilter';
@@ -16,6 +17,7 @@ import ol_line_simpleline from '../data/olFlatStyles/line_simpleline';
 import ol_text_placement_line from '../data/olFlatStyles/text_placement_line';
 import ol_point_icon_simple from '../data/olFlatStyles/point_icon_simple';
 import ol_point_simplepoint from '../data/olFlatStyles/point_simplepoint';
+import ol_point_opaquepoint from '../data/olFlatStyles/point_opaquepoint';
 import ol_multi_twoRulesSimplepoint from '../data/olFlatStyles/multi_twoRulesSimplepoint';
 import ol_filter_simpleFilter from '../data/olFlatStyles/filter_simpleFilter';
 import ol_filter_nestedFilter from '../data/olFlatStyles/filter_nestedFilter';
@@ -64,6 +66,12 @@ describe('OlFlatStyleParser implements StyleParser', () => {
       const { output: geostylerStyle } = await styleParser.readStyle(ol_point_simplepoint);
       expect(geostylerStyle).toBeDefined();
       expect(geostylerStyle).toEqual(pointSimplePoint);
+    });
+
+    it('reads a FlatCircle style with fill and stroke opacity', async () => {
+      const { output: geostylerStyle } = await styleParser.readStyle(ol_point_opaquepoint);
+      expect(geostylerStyle).toBeDefined();
+      expect(geostylerStyle).toEqual(pointOpaquePoint);
     });
 
     it('reads a style from a FlatStyleArray', async () => {

--- a/src/OlFlatStyleParser.ts
+++ b/src/OlFlatStyleParser.ts
@@ -276,7 +276,7 @@ export class OlFlatStyleParser implements StyleParser<FlatStyleLike> {
       wellKnownName: 'circle',
       radius: OlFlatStyleUtil.olExpressionToGsExpression<number>(flatStyle['circle-radius']),
       color: fillColor,
-      opacity: fillOpacity,
+      fillOpacity,
       strokeColor,
       strokeOpacity,
       strokeWidth: OlFlatStyleUtil.olExpressionToGsExpression<number>(flatStyle['circle-stroke-width']),


### PR DESCRIPTION
## Description

This sets the geostyler fillOpacity property for MarkSymbolizers instead of opacity.

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
